### PR TITLE
Benchmarks extra run (as first run is warmup)

### DIFF
--- a/src/main/scala/sdql/backend/CppCodegen.scala
+++ b/src/main/scala/sdql/backend/CppCodegen.scala
@@ -16,9 +16,10 @@ object CppCodegen {
     val queryBody  = run(e)(Map(), isTernary = false)
     val benchStart =
       if (benchmarkRuns == 0) ""
+      // note: first benchmark run is warmup
       else
         s"""HighPrecisionTimer timer;
-           |for (${cppType(IntType)} iter = 1; iter <= $benchmarkRuns; iter++) {
+           |for (${cppType(IntType)} iter = 0; iter <= $benchmarkRuns; iter++) {
            |timer.Reset();
            |""".stripMargin
     val benchStop  =


### PR DESCRIPTION
Thanks @amiralikaboli for pointing out `HighPrecisionTimer` discards the first run, e.g. here

https://github.com/edin-dal/sdql/blob/dcb2a8b2fd5c4ac2b07db9b3942137b305878bc3/runtime/high_precision_timer.h#L50
