### PR TITLE
Codegen for the MLIR backend

### DIFF
--- a/gen_tpch_mlir.sh
+++ b/gen_tpch_mlir.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+OUT_DIR="/Users/tmarzec/projects/scair/tests/filecheck/dialects/sdql/tpch-gen"
+mkdir -p "$OUT_DIR"
+
+failed=""
+
+for i in $(seq 1 22); do
+  q="q$i"
+  out="$OUT_DIR/$q.mlir"
+
+  echo "Generating $q... -> $out"
+  sbt --error "run to_mlir progs/tpch $q.sdql" > "$out" 2>&1
+
+  if [ $? -ne 0 ]; then
+    echo "  FAILED (see $out)"
+    failed="$failed $q"
+  fi
+done
+
+if [ -n "$failed" ]; then
+  echo "Done, failures:$failed"
+  exit 1
+else
+  echo "Done. Wrote files to: $OUT_DIR"
+fi

--- a/gen_tpch_mlir.sh
+++ b/gen_tpch_mlir.sh
@@ -1,6 +1,12 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
-OUT_DIR="/Users/tmarzec/projects/scair/tests/filecheck/dialects/sdql/tpch-gen"
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <out_dir>"
+  echo "Example: $0 ../scair/tests/filecheck/dialects/sdql/tpch-gen"
+  exit 2
+fi
+
+OUT_DIR="$1"
 mkdir -p "$OUT_DIR"
 
 failed=""

--- a/src/main/scala/sdql/backend/MlirCodegen.scala
+++ b/src/main/scala/sdql/backend/MlirCodegen.scala
@@ -530,7 +530,7 @@ object MlirCodegen {
         V(name, TypeInference.run(x))
 
       case _ =>
-        raise("¯\\_(ツ)_/¯ " + x)
+        raise("Unsupported expression in MLIR codegen: " + x)
     }
 
   private def upcastTo(v: V, target: Type)(implicit builder: MlirBuilder): V =

--- a/src/main/scala/sdql/backend/MlirCodegen.scala
+++ b/src/main/scala/sdql/backend/MlirCodegen.scala
@@ -9,28 +9,27 @@ object MlirCodegen {
 
   def mlirType(typ: Type): String =
     typ match {
-        case RealType => "f64"
-        case BoolType => "i1"
-        case IntType => "i32"
-        case LongType => "i64"
-        case DateType => "i32"
-        case DictType(keyT: Type, valueT: Type, _) =>
-            s"dictionary<${mlirType(keyT)}, ${mlirType(valueT)}>"
-        case RecordType(attrs: Seq[Attribute]) => {
-            val attrsTyped = attrs.map(attr => s"\"${attr.name}\" : ${mlirType(attr.tpe)})")
-            attrsTyped.mkString("record<", ", ", ">")
-        }
-        case StringType(Some(maxLen)) => s"memref<${maxLen}xi8>"
-        case StringType(None) => s"memref<?xi8>" 
-        case _ => raise(f"unhandled type $typ in MlirCodegen.mlirType()")
+      case RealType                              => "f64"
+      case BoolType                              => "i1"
+      case IntType                               => "i32"
+      case LongType                              => "i64"
+      case DateType                              => "i32"
+      case DictType(keyT: Type, valueT: Type, _) =>
+        s"dictionary<${mlirType(keyT)}, ${mlirType(valueT)}>"
+      case RecordType(attrs: Seq[Attribute])     =>
+        val attrsTyped = attrs.map(attr => s"\"${attr.name}\" : ${mlirType(attr.tpe)})")
+        attrsTyped.mkString("record<", ", ", ">")
+      case StringType(Some(maxLen))              => s"memref<${maxLen}xi8>"
+      case StringType(None)                      => s"memref<?xi8>"
+      case _                                     => raise(f"unhandled type $typ in MlirCodegen.mlirType()")
     }
 
   private final class Fresh {
-    private var i = 0
+    private var i                    = 0
     def next(prefix: String): String = {
-        val res = s"${prefix}_$i"
-        i = i + 1
-        res
+      val res = s"${prefix}_$i"
+      i = i + 1
+      res
     }
   }
 
@@ -39,191 +38,196 @@ object MlirCodegen {
   case class Emitted(code: Vector[String], value: String)
 
   def run(e: Exp): Emitted = {
-    def bindToName(x: Exp, desired: Option[String], expected: Option[Type] = None)(implicit ctx : TypesCtx): Emitted = x match {
-      // let x = e1 in e2
-      case LetBinding(x @ Sym(name), e1, e2) => {
-        val boundName = s"%$name"
-        val rhs = bindToName(e1, Some(boundName))
-        val ctx2 = ctx ++ Map(x -> TypeInference.run(e1)(ctx))
-        val body = bindToName(e2, None)(ctx2)
-        Emitted(rhs.code ++ body.code, body.value)
-      }
+    def bindToName(x: Exp, desired: Option[String], expected: Option[Type] = None)(implicit ctx: TypesCtx): Emitted =
+      x match {
+        // let x = e1 in e2
+        case LetBinding(x @ Sym(name), e1, e2) =>
+          val boundName = s"%$name"
+          val rhs       = bindToName(e1, Some(boundName))
+          val ctx2      = ctx ++ Map(x -> TypeInference.run(e1)(ctx))
+          val body      = bindToName(e2, None)(ctx2)
+          Emitted(rhs.code ++ body.code, body.value)
 
-      case Sym(name) => {
-        val res = s"%$name"
-        Emitted(Vector.empty, res)
-      }
+        case Sym(name) =>
+          val res = s"%$name"
+          Emitted(Vector.empty, res)
 
-      case Const(v: Int) => {
-        val binding = desired.getOrElse(fresh.next("%consti"))
-        val res = s"$binding = \"arith.constant\"() <{value = $v : i32}> : () -> i32"
-        Emitted(Vector(res), binding)
-      }
+        case Const(v: Int) =>
+          val binding = desired.getOrElse(fresh.next("%consti"))
+          val res     = s"$binding = \"arith.constant\"() <{value = $v : i32}> : () -> i32"
+          Emitted(Vector(res), binding)
 
-      case Const(v: Double) => {
-        val binding = desired.getOrElse(fresh.next("%constd"))
-        val res = s"$binding = \"arith.constant\"() <{value = $v : f64}> : () -> f64"
-        Emitted(Vector(res), binding)
-      }
+        case Const(v: Double) =>
+          val binding = desired.getOrElse(fresh.next("%constd"))
+          val res     = s"$binding = \"arith.constant\"() <{value = $v : f64}> : () -> f64"
+          Emitted(Vector(res), binding)
 
-      case Const(v: Boolean) => {
-        val binding = desired.getOrElse(fresh.next("%constb"))
-        val res = s"$binding = \"arith.constant\"() <{value = ${if(v) 1 else 0} : i1}> : () -> i1"
-        Emitted(Vector(res), binding)
-      }
+        case Const(v: Boolean)   =>
+          val binding = desired.getOrElse(fresh.next("%constb"))
+          val res     = s"$binding = \"arith.constant\"() <{value = ${if (v) 1 else 0} : i1}> : () -> i1"
+          Emitted(Vector(res), binding)
 
-      // TODO: what's mlir handling of date? for now its i32
-      case Const(v: DateValue) => {
-        val binding = desired.getOrElse(fresh.next("%constda"))
-        val res = s"$binding = \"arith.constant\"() <{value = ${v.v} : i32}> : () -> i32"
-        Emitted(Vector(res), binding)
-      }
+        // TODO: what's mlir handling of date? for now its i32
+        case Const(v: DateValue) =>
+          val binding = desired.getOrElse(fresh.next("%constda"))
+          val res     = s"$binding = \"arith.constant\"() <{value = ${v.v} : i32}> : () -> i32"
+          Emitted(Vector(res), binding)
 
-      case Const(v: String) => {
-        val binding = desired.getOrElse(fresh.next("%consts"))
-        val res = s"$binding = \"arith.constant\"() <{value = dense<[${v.getBytes().mkString("[", ", ", "]")}]}> : () -> memref<${v.size}xi1>"
-        Emitted(Vector(res), binding)
-      }
+        case Const(v: String)                             =>
+          val binding = desired.getOrElse(fresh.next("%consts"))
+          val res     =
+            s"$binding = \"arith.constant\"() <{value = dense<[${v.getBytes().mkString("[", ", ", "]")}]}> : () -> memref<${v.size}xi1>"
+          Emitted(Vector(res), binding)
 
-      // ex: %dict = sdql.empty_dictionary : dictionary<i32, f16>
-      case DictNode(Nil, _) => {
-        // TODO: handle empty dict (currently type inference breaks)
-        // raise(f"unhandled empty dictionary in MlirCodegen.bindToName()")
+        // ex: %dict = sdql.empty_dictionary : dictionary<i32, f16>
+        case DictNode(Nil, _)                             =>
+          // TODO: handle empty dict (currently type inference breaks)
+          // raise(f"unhandled empty dictionary in MlirCodegen.bindToName()")
 
-        val typ = mlirType(expected.get)
-        val binding = desired.getOrElse(fresh.next("%dict"))
-        Emitted(Vector(s"$binding = sdql.empty_dictionary : $typ"), binding)
-      }
+          val typ     = mlirType(expected.get)
+          val binding = desired.getOrElse(fresh.next("%dict"))
+          Emitted(Vector(s"$binding = sdql.empty_dictionary : $typ"), binding)
 
-      // ex: %8 = sdql.create_dictionary %5, %7 : i32, i1 -> dictionary<i32, i1>
-      case DictNode(args: Seq[(Exp, Exp)], _: DictHint) => {
-        val resultTyp = mlirType(TypeInference.run(x)(ctx))
-        val allArgs = args.flatMap { case (key, value) => Seq(key, value) }
-        val argTypes = allArgs.map { argTyp => mlirType(TypeInference.run(argTyp)(ctx))}.mkString(", ")
+        // ex: %8 = sdql.create_dictionary %5, %7 : i32, i1 -> dictionary<i32, i1>
+        case DictNode(args: Seq[(Exp, Exp)], _: DictHint) =>
+          val resultTyp = mlirType(TypeInference.run(x)(ctx))
+          val allArgs   = args.flatMap { case (key, value) => Seq(key, value) }
+          val argTypes  = allArgs.map(argTyp => mlirType(TypeInference.run(argTyp)(ctx))).mkString(", ")
 
-        val binding = desired.getOrElse(fresh.next("%dict"))
+          val binding = desired.getOrElse(fresh.next("%dict"))
 
-        val convertedArgs = allArgs.map(bindToName(_, None))
-        val argOps = convertedArgs.map(_.value).mkString(", ")
-        Emitted(convertedArgs.flatMap(_.code).toVector ++ Vector(s"$binding = sdql.create_dictionary $argOps : $argTypes -> $resultTyp"), binding)
-      }
-        
-      case Get(e1: Exp, e2: Exp) => {
-        val where = bindToName(e1, None)
+          val convertedArgs = allArgs.map(bindToName(_, None))
+          val argOps        = convertedArgs.map(_.value).mkString(", ")
+          Emitted(
+            convertedArgs.flatMap(_.code).toVector ++ Vector(
+              s"$binding = sdql.create_dictionary $argOps : $argTypes -> $resultTyp"
+            ),
+            binding
+          )
 
-        val what = bindToName(e2, None)
+        case Get(e1: Exp, e2: Exp) =>
+          val where = bindToName(e1, None)
 
-        val binding = desired.getOrElse(fresh.next("%get"))
+          val what = bindToName(e2, None)
 
-        TypeInference.run(e1) match {
-            case recType: RecordType => {
-              // %val = sdql.access_record %rec "a" : record<"a": i32, "b": f32> -> i32 
-              val res = s"$binding = sdql.access_record ${where.value} \"${what.value}\" : ${recType.attrs.map(attr => s"${attr.name}: ${mlirType(attr.tpe)}").mkString("record<", ", ", ">")}"
+          val binding = desired.getOrElse(fresh.next("%get"))
+
+          TypeInference.run(e1) match {
+            case recType: RecordType =>
+              // %val = sdql.access_record %rec "a" : record<"a": i32, "b": f32> -> i32
+              val res = s"$binding = sdql.access_record ${where.value} \"${what.value}\" : ${recType.attrs
+                  .map(attr => s"${attr.name}: ${mlirType(attr.tpe)}")
+                  .mkString("record<", ", ", ">")}"
               Emitted(where.code ++ what.code ++ Vector(res), binding)
-            }
-            case dictType: DictType => {
+            case dictType: DictType  =>
               // ex: %val = sdql.lookup_dictionary %dict [%key : i32] : dictionary<i32, f16> -> f16
-              val res = s"$binding = sdql.lookup_dictionary ${where.value} [${what.value} : ${mlirType(TypeInference.run(e2))}] : ${mlirType(dictType)} -> ${mlirType(dictType.value)}"
+              val res = s"$binding = sdql.lookup_dictionary ${where.value} [${what.value} : ${mlirType(
+                  TypeInference.run(e2)
+                )}] : ${mlirType(dictType)} -> ${mlirType(dictType.value)}"
               Emitted(where.code ++ what.code ++ Vector(res), binding)
-            }
-            case x => {
+            case x                   =>
               raise(f"unhandled lookup on type ${x.prettyPrint} in MlirCodegen.bindToName()")
-            }
-        }
-      }
+          }
 
-      case Load(_: String, _: Type, _: DictNode) => {
-        val binding = desired.getOrElse(fresh.next("%load"))
-        Emitted(Vector(s"$binding = load shananigans"), binding)
-      }
+        case Load(_: String, _: Type, _: DictNode)         =>
+          val binding = desired.getOrElse(fresh.next("%load"))
+          Emitted(Vector(s"$binding = load shananigans"), binding)
 
-      // sum (x in e1) body
+        // sum (x in e1) body
 
-      // %0 = sdql.empty_dictionary : dictionary<i32, f16>
+        // %0 = sdql.empty_dictionary : dictionary<i32, f16>
 
-      // %1 = sdql.sum %0 : dictionary<i32, f16> -> f16 {
-      // ^bb0(%x: record<"key": i32, "value": f16>):
-      //   %tmp = sdql.access_record %x "value" : record<"key": i32, "value": f16> -> f16
-      //   sdql.yield %tmp : f16
-      // }
-      case Sum(key: Sym, value: Sym, e1: Exp, body: Exp) => {
-        // key and value present in body but not in e1
-        val e1Evaled = bindToName(e1, None)
+        // %1 = sdql.sum %0 : dictionary<i32, f16> -> f16 {
+        // ^bb0(%x: record<"key": i32, "value": f16>):
+        //   %tmp = sdql.access_record %x "value" : record<"key": i32, "value": f16> -> f16
+        //   sdql.yield %tmp : f16
+        // }
+        case Sum(key: Sym, value: Sym, e1: Exp, body: Exp) =>
+          // key and value present in body but not in e1
+          val e1Evaled = bindToName(e1, None)
 
-        val binding = desired.getOrElse(fresh.next("%sum"))
+          val binding = desired.getOrElse(fresh.next("%sum"))
 
-        val prefix = s"$binding = sdql.sum ${e1Evaled.value} : ${mlirType(TypeInference.run(e1))}"
+          val prefix = s"$binding = sdql.sum ${e1Evaled.value} : ${mlirType(TypeInference.run(e1))}"
 
-        // result type? its type of body assuming proper binding key and value
-        val extendedCtx = TypeInference.run(e1) match {
+          // result type? its type of body assuming proper binding key and value
+          val extendedCtx = TypeInference.run(e1) match {
             case DictType(dictKey: Type, dictVal: Type, _) =>
-                ctx ++ Map(key -> dictKey, value -> dictVal)
-            case x =>
+              ctx ++ Map(key -> dictKey, value -> dictVal)
+            case x                                         =>
               raise(f"unhandled sum on type ${x.prettyPrint} in MlirCodegen.bindToName()")
-        }
+          }
 
-        val retType = mlirType(TypeInference.run(body)(extendedCtx))
+          val retType = mlirType(TypeInference.run(body)(extendedCtx))
 
-        val blockDecl = s"${fresh.next("^bb")}(%${key.name}: ${mlirType(extendedCtx.get(key).get)}, %${value.name}: ${mlirType(extendedCtx.get(value).get)}):"
-        val blockBody = bindToName(body, None)(extendedCtx)
-        val blockRet = s"  sdql.yield ${blockBody.value} : ${retType}"
+          val blockDecl =
+            s"${fresh.next("^bb")}(%${key.name}: ${mlirType(extendedCtx.get(key).get)}, %${value.name}: ${mlirType(extendedCtx.get(value).get)}):"
+          val blockBody = bindToName(body, None)(extendedCtx)
+          val blockRet  = s"  sdql.yield ${blockBody.value} : ${retType}"
 
-        // here we assume result of aggregation of elements of type retType is retType
-        val newOp = Vector(s"$prefix -> $retType {") ++ Vector(blockDecl) ++ blockBody.code.map("  " + _) ++ Vector(blockRet) ++ Vector("}")
-        Emitted(e1Evaled.code ++ newOp, "binding")
-      }
-      
-      // %res = sdql.create_record {fields = ["a", "b"]} %0, %1 : i32, f32 -> record<"a": i32, "b": f32>
-      case RecNode(values) => {
-        val fieldTypes = values.map(_._2).map(TypeInference.run(_))
-        val fieldNames = values.map(_._1)
+          // here we assume result of aggregation of elements of type retType is retType
+          val newOp = Vector(s"$prefix -> $retType {") ++ Vector(blockDecl) ++ blockBody.code.map("  " + _) ++ Vector(
+            blockRet
+          ) ++ Vector("}")
+          Emitted(e1Evaled.code ++ newOp, "binding")
 
-        val computedFields = values.map(_._2).map(bindToName(_, None))
-        val computedFieldTypes = fieldTypes.map(mlirType(_))
+        // %res = sdql.create_record {fields = ["a", "b"]} %0, %1 : i32, f32 -> record<"a": i32, "b": f32>
+        case RecNode(values)                               =>
+          val fieldTypes = values.map(_._2).map(TypeInference.run(_))
+          val fieldNames = values.map(_._1)
 
-        val binding = desired.getOrElse(fresh.next("%recnode"))
+          val computedFields     = values.map(_._2).map(bindToName(_, None))
+          val computedFieldTypes = fieldTypes.map(mlirType(_))
 
-        val fieldsAttr = s"{fields = ${fieldNames.map(name => s"\"$name\"").mkString("[", ", ", "]")}}"
-        
-        val retTypeFields = values.map(field => s"\"${field._1}\": ${mlirType(TypeInference.run(field._2))}").mkString("record<", ", ", ">")
+          val binding = desired.getOrElse(fresh.next("%recnode"))
 
-        val op = s"$binding = sdql.create_record $fieldsAttr ${computedFields.map(_.value).mkString(", ")} : ${computedFieldTypes.mkString(", ")} -> $retTypeFields"
-        Emitted(computedFields.flatMap(_.code).toVector ++ Vector(op), binding)
-      }
-        
-      // %val = sdql.access_record %rec "a" : record<"a": i32, "b": f32> -> i32
-      case FieldNode(e: Exp, f: String) => {
-        val inType = TypeInference.run(e) match {
+          val fieldsAttr = s"{fields = ${fieldNames.map(name => s"\"$name\"").mkString("[", ", ", "]")}}"
+
+          val retTypeFields = values
+            .map(field => s"\"${field._1}\": ${mlirType(TypeInference.run(field._2))}")
+            .mkString("record<", ", ", ">")
+
+          val op =
+            s"$binding = sdql.create_record $fieldsAttr ${computedFields.map(_.value).mkString(", ")} : ${computedFieldTypes
+                .mkString(", ")} -> $retTypeFields"
+          Emitted(computedFields.flatMap(_.code).toVector ++ Vector(op), binding)
+
+        // %val = sdql.access_record %rec "a" : record<"a": i32, "b": f32> -> i32
+        case FieldNode(e: Exp, f: String)                  =>
+          val inType            = TypeInference.run(e) match {
             case x @ RecordType(_) => x
-            case x @ _ => raise(f"unhandled field access on type ${x.prettyPrint} in MlirCodegen.bindToName()")
-        }
-        val accessedFieldType = inType.attrs.find(_.name == f) match {
+            case x @ _             => raise(f"unhandled field access on type ${x.prettyPrint} in MlirCodegen.bindToName()")
+          }
+          val accessedFieldType = inType.attrs.find(_.name == f) match {
             case Some(attr) => attr.tpe
-            case None => raise(f"unhandled field access due to missing field $f in ${inType.prettyPrint} in MlirCodegen.bindToName()")
-        }
-        val retTypeFields = inType.attrs.map(field => s"\"${field.name}\": ${mlirType(field.tpe)}").mkString("record<", ", ", ">")
+            case None       =>
+              raise(
+                f"unhandled field access due to missing field $f in ${inType.prettyPrint} in MlirCodegen.bindToName()"
+              )
+          }
+          val retTypeFields     =
+            inType.attrs.map(field => s"\"${field.name}\": ${mlirType(field.tpe)}").mkString("record<", ", ", ">")
 
-        val compE = bindToName(e, None)
+          val compE = bindToName(e, None)
 
-        val binding = desired.getOrElse(fresh.next("%fieldnode"))
+          val binding = desired.getOrElse(fresh.next("%fieldnode"))
 
-        val op = s"$binding = sdql.access_record ${compE.value} \"$f\" : $retTypeFields -> ${mlirType(accessedFieldType)} "
+          val op =
+            s"$binding = sdql.access_record ${compE.value} \"$f\" : $retTypeFields -> ${mlirType(accessedFieldType)} "
 
-        Emitted(compE.code ++ Vector(op), binding)
-      }
+          Emitted(compE.code ++ Vector(op), binding)
 
-      // %0 = "func.call"(%1) <{callee = @range_builtin}> : (i32) -> dictionary<i32, i1>
-      case RangeNode(e: Exp) => {
-        val compE = bindToName(e, None)
-        val binding = desired.getOrElse(fresh.next("%rangenode"))
-        val typ = mlirType(TypeInference.run(e))
+        // %0 = "func.call"(%1) <{callee = @range_builtin}> : (i32) -> dictionary<i32, i1>
+        case RangeNode(e: Exp)                             =>
+          val compE   = bindToName(e, None)
+          val binding = desired.getOrElse(fresh.next("%rangenode"))
+          val typ     = mlirType(TypeInference.run(e))
 
-        val op = s"$binding = \"func.call\"(${compE.value}) <{callee = @range_builtin}> : ($typ) -> dictionary<$typ, i32>"
-        Emitted(compE.code ++ Vector(op), binding)
-      }
+          val op =
+            s"$binding = \"func.call\"(${compE.value}) <{callee = @range_builtin}> : ($typ) -> dictionary<$typ, i32>"
+          Emitted(compE.code ++ Vector(op), binding)
 
-
-/* 
+        /*
     %res = "scf.if"(%cond) ({
         %mul = "arith.mulf"(%l_extendedprice, %l_discount) <{"fastmath" = #arith.fastmath<none>}> : (f64, f64) -> f64
         "scf.yield"(%mul) : (f64) -> ()
@@ -231,21 +235,21 @@ object MlirCodegen {
         %zero = "arith.constant"() <{value = 0.0 : f64}> : () -> f64
         "scf.yield"(%zero) : (f64) -> ()
     }) : (i1) -> f64
- */
-      case IfThenElse(cond, thenp, elsep) => {
-        val outT = mlirType(TypeInference.run(x))
+         */
+        case IfThenElse(cond, thenp, elsep)                =>
+          val outT = mlirType(TypeInference.run(x))
 
-        val c = bindToName(cond, None)
-        val cTyp = mlirType(TypeInference.run(cond))
+          val c    = bindToName(cond, None)
+          val cTyp = mlirType(TypeInference.run(cond))
 
-        val t = bindToName(thenp, None)
-        val tTyp = mlirType(TypeInference.run(thenp))
+          val t    = bindToName(thenp, None)
+          val tTyp = mlirType(TypeInference.run(thenp))
 
-        // val eTyp = mlirType(TypeInference.run(elsep))
-        val e = bindToName(elsep, None, Some(TypeInference.run(x)))
+          // val eTyp = mlirType(TypeInference.run(elsep))
+          val e = bindToName(elsep, None, Some(TypeInference.run(x)))
 
-        val binding = desired.getOrElse(fresh.next("%if"))
-        val code = c.code ++
+          val binding = desired.getOrElse(fresh.next("%if"))
+          val code    = c.code ++
             Vector(s"$binding = \"scf.if\"(${c.value}) ({") ++
             t.code.map("  " + _) ++
             Vector(s"  \"scf.yield\"(${t.value}) : ($tTyp) -> ()") ++
@@ -253,237 +257,228 @@ object MlirCodegen {
             e.code.map("  " + _) ++
             Vector(s"  \"scf.yield\"(${e.value}) : (${tTyp}) -> ()") ++
             Vector(s"}) : ($cTyp) -> $outT")
-        Emitted(code, binding)
-      }
-      
-      case Cmp(e1, e2, cmp) if (e2.isInstanceOf[DictNode] && e2.asInstanceOf[DictNode].map == Nil) => {
-        // is it always i1?
-        val outT = mlirType(TypeInference.run(x))
+          Emitted(code, binding)
 
-        val predicateVal = cmp match {
-          // https://mlir.llvm.org/docs/Dialects/ArithOps/#cmpfpredicate
-          case "<=" => 5
-          case "<" => 4
-          case "!=" => 6
-        }
-        val comp1 = bindToName(e1, None)
-        val type1 = TypeInference.run(e1)
-        val t1 = mlirType(type1)
-        val comp2 = bindToName(e2, None, Some(type1))
-        val t2 = t1
+        case Cmp(e1, e2, cmp) if (e2.isInstanceOf[DictNode] && e2.asInstanceOf[DictNode].map == Nil) =>
+          // is it always i1?
+          val outT = mlirType(TypeInference.run(x))
 
-        val binding = desired.getOrElse(fresh.next("%cmpf"))
+          val predicateVal = cmp match {
+            // https://mlir.llvm.org/docs/Dialects/ArithOps/#cmpfpredicate
+            case "<=" => 5
+            case "<"  => 4
+            case "!=" => 6
+          }
+          val comp1        = bindToName(e1, None)
+          val type1        = TypeInference.run(e1)
+          val t1           = mlirType(type1)
+          val comp2        = bindToName(e2, None, Some(type1))
+          val t2           = t1
 
-        val op = s"$binding = \"arith.cmpf\"(${comp1.value}, ${comp2.value}) <{fastmath = #arith.fastmath<none>, predicate = $predicateVal}> : ($t1, $t2) -> $outT"
-        Emitted(comp1.code ++ comp2.code ++ Vector(op), binding)
-      }
+          val binding = desired.getOrElse(fresh.next("%cmpf"))
 
-      // %2 = "arith.cmpi"(%0, %1) <{predicate = 3}> : (i32, i32) -> i1
-      case Cmp(e1, e2, cmp)
-        if (TypeInference.run(e1) == IntType || TypeInference.run(e1) == LongType || TypeInference.run(e1) == DateType) &&
-          (TypeInference.run(e2) == IntType || TypeInference.run(e2) == LongType || TypeInference.run(e2) == DateType) => {
+          val op =
+            s"$binding = \"arith.cmpf\"(${comp1.value}, ${comp2.value}) <{fastmath = #arith.fastmath<none>, predicate = $predicateVal}> : ($t1, $t2) -> $outT"
+          Emitted(comp1.code ++ comp2.code ++ Vector(op), binding)
+
+        // %2 = "arith.cmpi"(%0, %1) <{predicate = 3}> : (i32, i32) -> i1
+        case Cmp(e1, e2, cmp)
+            if (TypeInference.run(e1) == IntType || TypeInference
+              .run(e1) == LongType || TypeInference.run(e1) == DateType) &&
+              (TypeInference.run(e2) == IntType || TypeInference
+                .run(e2) == LongType || TypeInference.run(e2) == DateType) =>
           // is it always i1?
           val outT = mlirType(TypeInference.run(x))
 
           val predicateVal = cmp match {
             // https://mlir.llvm.org/docs/Dialects/ArithOps/#cmpipredicate
             case "<=" => 3
-            case "<" => 2
+            case "<"  => 2
             case "==" => 0
             case "!=" => 1
           }
-          val comp1 = bindToName(e1, None)
-          val t1 = mlirType(TypeInference.run(e1))
-          val comp2 = bindToName(e2, None)
-          val t2 = mlirType(TypeInference.run(e2))
+          val comp1        = bindToName(e1, None)
+          val t1           = mlirType(TypeInference.run(e1))
+          val comp2        = bindToName(e2, None)
+          val t2           = mlirType(TypeInference.run(e2))
 
           val binding = desired.getOrElse(fresh.next("%cmpi"))
 
-          val op = s"$binding = \"arith.cmpi\"(${comp1.value}, ${comp2.value}) <{predicate = $predicateVal}> : ($t1, $t2) -> $outT"
+          val op =
+            s"$binding = \"arith.cmpi\"(${comp1.value}, ${comp2.value}) <{predicate = $predicateVal}> : ($t1, $t2) -> $outT"
           Emitted(comp1.code ++ comp2.code ++ Vector(op), binding)
-        }
 
-      case Cmp(e1, e2, cmp) if (TypeInference.run(e1) == RealType || TypeInference.run(e1) == RealType) => {
-        // is it always i1?
-        val outT = mlirType(TypeInference.run(x))
-
-        val predicateVal = cmp match {
-          // https://mlir.llvm.org/docs/Dialects/ArithOps/#cmpfpredicate
-          case "<=" => 5
-          case "<" => 4
-          case "!=" => 6
-          case "==" => 1
-        }
-        val comp1 = bindToName(e1, None)
-        val t1 = mlirType(TypeInference.run(e1))
-        val comp2 = bindToName(e2, None)
-        val t2 = mlirType(TypeInference.run(e2))
-
-        val binding = desired.getOrElse(fresh.next("%cmpf"))
-
-        val op = s"$binding = \"arith.cmpf\"(${comp1.value}, ${comp2.value}) <{fastmath = #arith.fastmath<none>, predicate = $predicateVal}> : ($t1, $t2) -> $outT"
-        Emitted(comp1.code ++ comp2.code ++ Vector(op), binding)
-      }
-
-      // %a = arith.muli %b, %c : i64
-      case Mult(e1, e2)
-        if (TypeInference.run(e1) == IntType || TypeInference.run(e1) == LongType) &&
-          (TypeInference.run(e2) == IntType || TypeInference.run(e2) == LongType) => {
+        case Cmp(e1, e2, cmp) if (TypeInference.run(e1) == RealType || TypeInference.run(e1) == RealType) =>
+          // is it always i1?
           val outT = mlirType(TypeInference.run(x))
-          
+
+          val predicateVal = cmp match {
+            // https://mlir.llvm.org/docs/Dialects/ArithOps/#cmpfpredicate
+            case "<=" => 5
+            case "<"  => 4
+            case "!=" => 6
+            case "==" => 1
+          }
+          val comp1        = bindToName(e1, None)
+          val t1           = mlirType(TypeInference.run(e1))
+          val comp2        = bindToName(e2, None)
+          val t2           = mlirType(TypeInference.run(e2))
+
+          val binding = desired.getOrElse(fresh.next("%cmpf"))
+
+          val op =
+            s"$binding = \"arith.cmpf\"(${comp1.value}, ${comp2.value}) <{fastmath = #arith.fastmath<none>, predicate = $predicateVal}> : ($t1, $t2) -> $outT"
+          Emitted(comp1.code ++ comp2.code ++ Vector(op), binding)
+
+        // %a = arith.muli %b, %c : i64
+        case Mult(e1, e2)
+            if (TypeInference.run(e1) == IntType || TypeInference.run(e1) == LongType) &&
+              (TypeInference.run(e2) == IntType || TypeInference.run(e2) == LongType) =>
+          val outT = mlirType(TypeInference.run(x))
+
           val binding = desired.getOrElse(fresh.next("%multi"))
 
           val comp1 = bindToName(e1, None)
-          val t1 = mlirType(TypeInference.run(e1))
+          val t1    = mlirType(TypeInference.run(e1))
           val comp2 = bindToName(e2, None)
-          val t2 = mlirType(TypeInference.run(e2))
+          val t2    = mlirType(TypeInference.run(e2))
 
           val op = s"$binding = \"arith.muli\"(${comp1.value}, ${comp2.value}) : ($t1, $t2) -> $outT"
           Emitted(comp1.code ++ comp2.code ++ Vector(op), binding)
-      }
 
-      case Mult(e1, e2) if TypeInference.run(e1) == RealType || TypeInference.run(e2) == RealType => {
+        case Mult(e1, e2) if TypeInference.run(e1) == RealType || TypeInference.run(e2) == RealType =>
           val outT = mlirType(TypeInference.run(x))
-          
+
           val binding = desired.getOrElse(fresh.next("%multf"))
 
           val comp1 = bindToName(e1, None)
-          val t1 = mlirType(TypeInference.run(e1))
+          val t1    = mlirType(TypeInference.run(e1))
           val comp2 = bindToName(e2, None)
-          val t2 = mlirType(TypeInference.run(e2))
+          val t2    = mlirType(TypeInference.run(e2))
 
-          val op = s"$binding = \"arith.mulf\"(${comp1.value}, ${comp2.value}) <{fastmath = #arith.fastmath<none>}> : ($t1, $t2) -> $outT"
+          val op =
+            s"$binding = \"arith.mulf\"(${comp1.value}, ${comp2.value}) <{fastmath = #arith.fastmath<none>}> : ($t1, $t2) -> $outT"
           Emitted(comp1.code ++ comp2.code ++ Vector(op), binding)
-      }
 
-      case Add(e1, e2) if List(IntType, LongType).contains(TypeInference.run(e1)) => {
+        case Add(e1, e2) if List(IntType, LongType).contains(TypeInference.run(e1)) =>
           val outT = mlirType(TypeInference.run(x))
-          
+
           val binding = desired.getOrElse(fresh.next("%addi"))
 
           val comp1 = bindToName(e1, None)
-          val t1 = mlirType(TypeInference.run(e1))
+          val t1    = mlirType(TypeInference.run(e1))
           val comp2 = bindToName(e2, None)
-          val t2 = mlirType(TypeInference.run(e2))
+          val t2    = mlirType(TypeInference.run(e2))
 
           val op = s"$binding = \"arith.addi\"(${comp1.value}, ${comp2.value}) : ($t1, $t2) -> $outT"
           Emitted(comp1.code ++ comp2.code ++ Vector(op), binding)
 
-      }
-
-      case Add(e1, e2) if TypeInference.run(e1) == RealType => {
+        case Add(e1, e2) if TypeInference.run(e1) == RealType =>
           val outT = mlirType(TypeInference.run(x))
-          
+
           val binding = desired.getOrElse(fresh.next("%addf"))
 
           val comp1 = bindToName(e1, None)
-          val t1 = mlirType(TypeInference.run(e1))
+          val t1    = mlirType(TypeInference.run(e1))
           val comp2 = bindToName(e2, None)
-          val t2 = mlirType(TypeInference.run(e2))
+          val t2    = mlirType(TypeInference.run(e2))
 
-          val op = s"$binding = \"arith.addf\"(${comp1.value}, ${comp2.value}) <{fastmath = #arith.fastmath<none>}> : ($t1, $t2) -> $outT"
+          val op =
+            s"$binding = \"arith.addf\"(${comp1.value}, ${comp2.value}) <{fastmath = #arith.fastmath<none>}> : ($t1, $t2) -> $outT"
           Emitted(comp1.code ++ comp2.code ++ Vector(op), binding)
-      }
 
-      case Neg(e) if TypeInference.run(e) == BoolType => {
-        val zero = desired.getOrElse(fresh.next("%zero"))
-        val zeroOp = s"$zero = \"arith.constant\"() <{value = 0 : i1}> : () -> i1"
+        case Neg(e) if TypeInference.run(e) == BoolType                       =>
+          val zero   = desired.getOrElse(fresh.next("%zero"))
+          val zeroOp = s"$zero = \"arith.constant\"() <{value = 0 : i1}> : () -> i1"
 
-        // val res = s"$binding = \"arith.constant\"() <{value = $v : i32}> : () -> i32"
+          // val res = s"$binding = \"arith.constant\"() <{value = $v : i32}> : () -> i32"
 
-        val binding = desired.getOrElse(fresh.next("%neg"))
+          val binding = desired.getOrElse(fresh.next("%neg"))
 
-        val comp = bindToName(e, None)
-        val op = s"$binding = \"arith.cmpi\"(${comp.value}, $zero) <{predicate = 0}> : (i1, i1) -> i1"
-        Emitted(comp.code ++ Vector(zeroOp, op), comp.value)
-      }
-      case Neg(e) if List(IntType, LongType).contains(TypeInference.run(e)) => {          
+          val comp = bindToName(e, None)
+          val op   = s"$binding = \"arith.cmpi\"(${comp.value}, $zero) <{predicate = 0}> : (i1, i1) -> i1"
+          Emitted(comp.code ++ Vector(zeroOp, op), comp.value)
+        case Neg(e) if List(IntType, LongType).contains(TypeInference.run(e)) =>
           val binding = desired.getOrElse(fresh.next("%addf"))
 
           val comp = bindToName(e, None)
-          val t = mlirType(TypeInference.run(e))
+          val t    = mlirType(TypeInference.run(e))
 
-          val zero = desired.getOrElse(fresh.next("%zero"))
+          val zero   = desired.getOrElse(fresh.next("%zero"))
           val zeroOp = s"$zero = \"arith.constant\"() <{value = 0 : $t}> : () -> $t"
 
           val op = s"$binding = \"arith.subi\"($zero, ${comp.value}) : ($t, $t) -> $t"
           Emitted(comp.code ++ Vector(zeroOp) ++ Vector(op), binding)
-      }
-      case Neg(e) if TypeInference.run(e) == RealType => {          
+        case Neg(e) if TypeInference.run(e) == RealType                       =>
           val binding = desired.getOrElse(fresh.next("%addf"))
 
           val comp = bindToName(e, None)
-          val t = mlirType(TypeInference.run(e))
+          val t    = mlirType(TypeInference.run(e))
 
-          val zero = desired.getOrElse(fresh.next("%zero"))
+          val zero   = desired.getOrElse(fresh.next("%zero"))
           val zeroOp = s"$zero = \"arith.constant\"() <{value = 0 : $t}> : () -> $t"
 
-          val op = s"$binding = \"arith.subf\"($zero, ${comp.value}) <{fastmath = #arith.fastmath<none>}> : ($t, $t) -> $t"
+          val op =
+            s"$binding = \"arith.subf\"($zero, ${comp.value}) <{fastmath = #arith.fastmath<none>}> : ($t, $t) -> $t"
           Emitted(comp.code ++ Vector(zeroOp) ++ Vector(op), binding)
-      }
 
-      case Concat(e1, e2)
-      if TypeInference.run(e1).isInstanceOf[RecordType] && TypeInference.run(e2).isInstanceOf[RecordType] => {
-        val outT = TypeInference.run(x)
+        case Concat(e1, e2)
+            if TypeInference.run(e1).isInstanceOf[RecordType] && TypeInference.run(e2).isInstanceOf[RecordType] =>
+          val outT = TypeInference.run(x)
 
-        val typ1 = mlirType(TypeInference.run(e1))
-        val typ2 = mlirType(TypeInference.run(e2))
+          val typ1 = mlirType(TypeInference.run(e1))
+          val typ2 = mlirType(TypeInference.run(e2))
 
-        val gen1 = bindToName(e1, None)
-        val gen2 = bindToName(e2, None)
+          val gen1 = bindToName(e1, None)
+          val gen2 = bindToName(e2, None)
 
-        val binding = desired.getOrElse(fresh.next("%concat"))
+          val binding = desired.getOrElse(fresh.next("%concat"))
 
-        val op = s"$binding = sdql.concat ${gen1.value}, ${gen2.value} : $typ1, $typ2 -> $outT"
-        Emitted(gen1.code ++ gen2.code ++ Vector(op), binding)
-      }
+          val op = s"$binding = sdql.concat ${gen1.value}, ${gen2.value} : $typ1, $typ2 -> $outT"
+          Emitted(gen1.code ++ gen2.code ++ Vector(op), binding)
 
-      case External(name, args) => {
-        val outT = TypeInference.run(x)
-        
-        val generated = args.map(bindToName(_, None))
-        val types = args.map(TypeInference.run)
-        println(s"name=$name, types=$types")
-        val binding = desired.getOrElse(fresh.next("%external"))
+        case External(name, args) =>
+          val outT = TypeInference.run(x)
 
-        val op = s"$binding = sdql.external $name, ${generated.map(_.value).mkString(", ")} : ${types.map(mlirType)}} : ${mlirType(outT)}"
-        Emitted(generated.flatMap(_.code).toVector ++ Vector(op), binding)
-      }
+          val generated = args.map(bindToName(_, None))
+          val types     = args.map(TypeInference.run)
+          println(s"name=$name, types=$types")
+          val binding   = desired.getOrElse(fresh.next("%external"))
 
-      case Cmp(e1, e2, cmp) if cmp == "==" => {
-        val outT = TypeInference.run(x)
+          val op =
+            s"$binding = sdql.external $name, ${generated.map(_.value).mkString(", ")} : ${types.map(mlirType)}} : ${mlirType(outT)}"
+          Emitted(generated.flatMap(_.code).toVector ++ Vector(op), binding)
 
-        val typ1 = mlirType(TypeInference.run(e1))
-        val typ2 = e2 match {
+        case Cmp(e1, e2, cmp) if cmp == "==" =>
+          val outT = TypeInference.run(x)
+
+          val typ1 = mlirType(TypeInference.run(e1))
+          val typ2 = e2 match {
             // workaround for `a != { }`
             case DictNode(Nil, _) => typ1
-            case _ => mlirType(TypeInference.run(e2))
-        }
+            case _                => mlirType(TypeInference.run(e2))
+          }
 
-        val gen1 = bindToName(e1, None)
-        // workaround for a != { }
-        val gen2 = bindToName(e2, None, expected = Some(TypeInference.run(e1)))
+          val gen1 = bindToName(e1, None)
+          // workaround for a != { }
+          val gen2 = bindToName(e2, None, expected = Some(TypeInference.run(e1)))
 
-        val binding = desired.getOrElse(fresh.next("%cmp"))
+          val binding = desired.getOrElse(fresh.next("%cmp"))
 
-        val op = s"$binding = sdql.cmp ${gen1.value}, ${gen2.value} : $typ1, $typ2 -> $outT"
-        Emitted(gen1.code ++ gen2.code ++ Vector(op), binding)
+          val op = s"$binding = sdql.cmp ${gen1.value}, ${gen2.value} : $typ1, $typ2 -> $outT"
+          Emitted(gen1.code ++ gen2.code ++ Vector(op), binding)
+
+        case Cmp(e1, e2, cmp) if cmp == "!=" =>
+          val negated = Cmp(e1, e2, "==")
+          bindToName(Neg(negated), desired, expected)
+
+        case Unique(_) =>
+          println("unique... " + TypeInference.run(x).prettyPrint)
+          Emitted(Vector.empty, "")
+
+        case _ =>
+          raise("¯\\_(ツ)_/¯ " + x)
       }
-
-      case Cmp(e1, e2, cmp) if cmp == "!=" => {
-        val negated = Cmp(e1, e2, "==")
-        bindToName(Neg(negated), desired, expected)
-      }
-
-      case Unique(_) => {
-        println("unique... " + TypeInference.run(x).prettyPrint)
-        Emitted(Vector.empty, "")
-      }
-
-      case _ => {
-        raise("¯\\_(ツ)_/¯ " + x)
-      }
-    }
 
     bindToName(e, None)(Map.empty)
   }

--- a/src/main/scala/sdql/backend/MlirCodegen.scala
+++ b/src/main/scala/sdql/backend/MlirCodegen.scala
@@ -20,8 +20,8 @@ object MlirCodegen {
             val attrsTyped = attrs.map(attr => s"\"${attr.name}\" : ${mlirType(attr.tpe)})")
             attrsTyped.mkString("record<", ", ", ">")
         }
-        case StringType(Some(maxLen)) => s"vector<${maxLen}xi8>"
-        case StringType(None) => raise("StringType(None) no supported in MlirCodegen.mlirType()") 
+        case StringType(Some(maxLen)) => s"memref<${maxLen}xi8>"
+        case StringType(None) => s"memref<?xi8>" 
         case _ => raise(f"unhandled type $typ in MlirCodegen.mlirType()")
     }
 
@@ -79,6 +79,12 @@ object MlirCodegen {
         Emitted(Vector(res), binding)
       }
 
+      case Const(v: String) => {
+        val binding = desired.getOrElse(fresh.next("%consts"))
+        val res = s"$binding = \"arith.constant\"() <{value = dense<[${v.getBytes().mkString("[", ", ", "]")}]}> : () -> memref<${v.size}xi1>"
+        Emitted(Vector(res), binding)
+      }
+
       // ex: %dict = sdql.empty_dictionary : dictionary<i32, f16>
       case DictNode(Nil, _) => {
         // TODO: handle empty dict (currently type inference breaks)
@@ -110,8 +116,10 @@ object MlirCodegen {
         val binding = desired.getOrElse(fresh.next("%get"))
 
         TypeInference.run(e1) match {
-            case _: RecordType => {
-              raise(f"unhandled lookup on RecordType in MlirCodegen.bindToName()")
+            case recType: RecordType => {
+              // %val = sdql.access_record %rec "a" : record<"a": i32, "b": f32> -> i32 
+              val res = s"$binding = sdql.access_record ${where.value} \"${what.value}\" : ${recType.attrs.map(attr => s"${attr.name}: ${mlirType(attr.tpe)}").mkString("record<", ", ", ">")}"
+              Emitted(where.code ++ what.code ++ Vector(res), binding)
             }
             case dictType: DictType => {
               // ex: %val = sdql.lookup_dictionary %dict [%key : i32] : dictionary<i32, f16> -> f16
@@ -248,6 +256,28 @@ object MlirCodegen {
         Emitted(code, binding)
       }
       
+      case Cmp(e1, e2, cmp) if (e2.isInstanceOf[DictNode] && e2.asInstanceOf[DictNode].map == Nil) => {
+        // is it always i1?
+        val outT = mlirType(TypeInference.run(x))
+
+        val predicateVal = cmp match {
+          // https://mlir.llvm.org/docs/Dialects/ArithOps/#cmpfpredicate
+          case "<=" => 5
+          case "<" => 4
+          case "!=" => 6
+        }
+        val comp1 = bindToName(e1, None)
+        val type1 = TypeInference.run(e1)
+        val t1 = mlirType(type1)
+        val comp2 = bindToName(e2, None, Some(type1))
+        val t2 = t1
+
+        val binding = desired.getOrElse(fresh.next("%cmpf"))
+
+        val op = s"$binding = \"arith.cmpf\"(${comp1.value}, ${comp2.value}) <{fastmath = #arith.fastmath<none>, predicate = $predicateVal}> : ($t1, $t2) -> $outT"
+        Emitted(comp1.code ++ comp2.code ++ Vector(op), binding)
+      }
+
       // %2 = "arith.cmpi"(%0, %1) <{predicate = 3}> : (i32, i32) -> i1
       case Cmp(e1, e2, cmp)
         if (TypeInference.run(e1) == IntType || TypeInference.run(e1) == LongType || TypeInference.run(e1) == DateType) &&
@@ -259,6 +289,8 @@ object MlirCodegen {
             // https://mlir.llvm.org/docs/Dialects/ArithOps/#cmpipredicate
             case "<=" => 3
             case "<" => 2
+            case "==" => 0
+            case "!=" => 1
           }
           val comp1 = bindToName(e1, None)
           val t1 = mlirType(TypeInference.run(e1))
@@ -270,8 +302,8 @@ object MlirCodegen {
           val op = s"$binding = \"arith.cmpi\"(${comp1.value}, ${comp2.value}) <{predicate = $predicateVal}> : ($t1, $t2) -> $outT"
           Emitted(comp1.code ++ comp2.code ++ Vector(op), binding)
         }
-    
-      case Cmp(e1, e2, cmp) if (TypeInference.run(e1) == RealType || TypeInference.run(e2) == RealType) => {
+
+      case Cmp(e1, e2, cmp) if (TypeInference.run(e1) == RealType || TypeInference.run(e1) == RealType) => {
         // is it always i1?
         val outT = mlirType(TypeInference.run(x))
 
@@ -279,6 +311,8 @@ object MlirCodegen {
           // https://mlir.llvm.org/docs/Dialects/ArithOps/#cmpfpredicate
           case "<=" => 5
           case "<" => 4
+          case "!=" => 6
+          case "==" => 1
         }
         val comp1 = bindToName(e1, None)
         val t1 = mlirType(TypeInference.run(e1))
@@ -351,18 +385,18 @@ object MlirCodegen {
           Emitted(comp1.code ++ comp2.code ++ Vector(op), binding)
       }
 
-    //   case Neg(e) if TypeInference.run(e) == BoolType => {
-    //     val zero = desired.getOrElse(fresh.next("%zero"))
-    //     val zeroOp = s"$zero = \"arith.constant\"() <{value = 0 : i1}> : () -> i1"
+      case Neg(e) if TypeInference.run(e) == BoolType => {
+        val zero = desired.getOrElse(fresh.next("%zero"))
+        val zeroOp = s"$zero = \"arith.constant\"() <{value = 0 : i1}> : () -> i1"
 
-    //     // val res = s"$binding = \"arith.constant\"() <{value = $v : i32}> : () -> i32"
+        // val res = s"$binding = \"arith.constant\"() <{value = $v : i32}> : () -> i32"
 
-    //     val binding = desired.getOrElse(fresh.next("%neg"))
+        val binding = desired.getOrElse(fresh.next("%neg"))
 
-    //     val comp = bindToName(e, None)
-    //     val op = s"$binding = \"arith.cmpi\"(${comp.value}, $zero) <{predicate = 0}> : (i1, i1) -> i1"
-    //     Emitted(comp.code ++ Vector(zeroOp, op), comp.value)
-    //   }
+        val comp = bindToName(e, None)
+        val op = s"$binding = \"arith.cmpi\"(${comp.value}, $zero) <{predicate = 0}> : (i1, i1) -> i1"
+        Emitted(comp.code ++ Vector(zeroOp, op), comp.value)
+      }
       case Neg(e) if List(IntType, LongType).contains(TypeInference.run(e)) => {          
           val binding = desired.getOrElse(fresh.next("%addf"))
 
@@ -402,6 +436,48 @@ object MlirCodegen {
 
         val op = s"$binding = sdql.concat ${gen1.value}, ${gen2.value} : $typ1, $typ2 -> $outT"
         Emitted(gen1.code ++ gen2.code ++ Vector(op), binding)
+      }
+
+      case External(name, args) => {
+        val outT = TypeInference.run(x)
+        
+        val generated = args.map(bindToName(_, None))
+        val types = args.map(TypeInference.run)
+        println(s"name=$name, types=$types")
+        val binding = desired.getOrElse(fresh.next("%external"))
+
+        val op = s"$binding = sdql.external $name, ${generated.map(_.value).mkString(", ")} : ${types.map(mlirType)}} : ${mlirType(outT)}"
+        Emitted(generated.flatMap(_.code).toVector ++ Vector(op), binding)
+      }
+
+      case Cmp(e1, e2, cmp) if cmp == "==" => {
+        val outT = TypeInference.run(x)
+
+        val typ1 = mlirType(TypeInference.run(e1))
+        val typ2 = e2 match {
+            // workaround for `a != { }`
+            case DictNode(Nil, _) => typ1
+            case _ => mlirType(TypeInference.run(e2))
+        }
+
+        val gen1 = bindToName(e1, None)
+        // workaround for a != { }
+        val gen2 = bindToName(e2, None, expected = Some(TypeInference.run(e1)))
+
+        val binding = desired.getOrElse(fresh.next("%cmp"))
+
+        val op = s"$binding = sdql.cmp ${gen1.value}, ${gen2.value} : $typ1, $typ2 -> $outT"
+        Emitted(gen1.code ++ gen2.code ++ Vector(op), binding)
+      }
+
+      case Cmp(e1, e2, cmp) if cmp == "!=" => {
+        val negated = Cmp(e1, e2, "==")
+        bindToName(Neg(negated), desired, expected)
+      }
+
+      case Unique(_) => {
+        println("unique... " + TypeInference.run(x).prettyPrint)
+        Emitted(Vector.empty, "")
       }
 
       case _ => {

--- a/src/main/scala/sdql/backend/MlirCodegen.scala
+++ b/src/main/scala/sdql/backend/MlirCodegen.scala
@@ -17,469 +17,503 @@ object MlirCodegen {
       case DictType(keyT: Type, valueT: Type, _) =>
         s"dictionary<${mlirType(keyT)}, ${mlirType(valueT)}>"
       case RecordType(attrs: Seq[Attribute])     =>
-        val attrsTyped = attrs.map(attr => s"\"${attr.name}\" : ${mlirType(attr.tpe)})")
+        val attrsTyped = attrs.map(attr => s"\"${attr.name}\" : ${mlirType(attr.tpe)}")
         attrsTyped.mkString("record<", ", ", ">")
       case StringType(Some(maxLen))              => s"memref<${maxLen}xi8>"
       case StringType(None)                      => s"memref<?xi8>"
       case _                                     => raise(f"unhandled type $typ in MlirCodegen.mlirType()")
     }
 
-  private final class Fresh {
-    private var i                    = 0
-    def next(prefix: String): String = {
+  final case class V(name: String, typ: Type)
+
+  final class MlirBuilder {
+    private var i           = 0
+    private val out         = Vector.newBuilder[String]
+    private var indentLevel = 0
+
+    def result: Vector[String] = out.result()
+
+    def line(s: String): Unit = {
+      val indent = "  " * indentLevel
+      out += indent + s
+    }
+
+    def fresh(prefix: String = "%t"): String = {
       val res = s"${prefix}_$i"
-      i = i + 1
+      i += 1
       res
+    }
+
+    def withIndent[A](k: => A): A = {
+      indentLevel += 1
+      val r = k
+      indentLevel -= 1
+      r
     }
   }
 
-  private val fresh = new Fresh
+  def run(e: Exp): Vector[String] = {
+    // val builder = new MlirBuilder
+    val ctx     = Map.empty[Sym, Type]
+    val builder = new MlirBuilder
 
-  case class Emitted(code: Vector[String], value: String)
+    bindToName(e, None, expectedType = None)(ctx, builder)
 
-  def run(e: Exp): Emitted = {
-    def bindToName(x: Exp, desired: Option[String], expected: Option[Type] = None)(implicit ctx: TypesCtx): Emitted =
-      x match {
-        // let x = e1 in e2
-        case LetBinding(x @ Sym(name), e1, e2) =>
-          val boundName = s"%$name"
-          val rhs       = bindToName(e1, Some(boundName))
-          val ctx2      = ctx ++ Map(x -> TypeInference.run(e1)(ctx))
-          val body      = bindToName(e2, None)(ctx2)
-          Emitted(rhs.code ++ body.code, body.value)
-
-        case Sym(name) =>
-          val res = s"%$name"
-          Emitted(Vector.empty, res)
-
-        case Const(v: Int) =>
-          val binding = desired.getOrElse(fresh.next("%consti"))
-          val res     = s"$binding = \"arith.constant\"() <{value = $v : i32}> : () -> i32"
-          Emitted(Vector(res), binding)
-
-        case Const(v: Double) =>
-          val binding = desired.getOrElse(fresh.next("%constd"))
-          val res     = s"$binding = \"arith.constant\"() <{value = $v : f64}> : () -> f64"
-          Emitted(Vector(res), binding)
-
-        case Const(v: Boolean)   =>
-          val binding = desired.getOrElse(fresh.next("%constb"))
-          val res     = s"$binding = \"arith.constant\"() <{value = ${if (v) 1 else 0} : i1}> : () -> i1"
-          Emitted(Vector(res), binding)
-
-        // TODO: what's mlir handling of date? for now its i32
-        case Const(v: DateValue) =>
-          val binding = desired.getOrElse(fresh.next("%constda"))
-          val res     = s"$binding = \"arith.constant\"() <{value = ${v.v} : i32}> : () -> i32"
-          Emitted(Vector(res), binding)
-
-        case Const(v: String)                             =>
-          val binding = desired.getOrElse(fresh.next("%consts"))
-          val res     =
-            s"$binding = \"arith.constant\"() <{value = dense<[${v.getBytes().mkString("[", ", ", "]")}]}> : () -> memref<${v.size}xi1>"
-          Emitted(Vector(res), binding)
-
-        // ex: %dict = sdql.empty_dictionary : dictionary<i32, f16>
-        case DictNode(Nil, _)                             =>
-          // TODO: handle empty dict (currently type inference breaks)
-          // raise(f"unhandled empty dictionary in MlirCodegen.bindToName()")
-
-          val typ     = mlirType(expected.get)
-          val binding = desired.getOrElse(fresh.next("%dict"))
-          Emitted(Vector(s"$binding = sdql.empty_dictionary : $typ"), binding)
-
-        // ex: %8 = sdql.create_dictionary %5, %7 : i32, i1 -> dictionary<i32, i1>
-        case DictNode(args: Seq[(Exp, Exp)], _: DictHint) =>
-          val resultTyp = mlirType(TypeInference.run(x)(ctx))
-          val allArgs   = args.flatMap { case (key, value) => Seq(key, value) }
-          val argTypes  = allArgs.map(argTyp => mlirType(TypeInference.run(argTyp)(ctx))).mkString(", ")
-
-          val binding = desired.getOrElse(fresh.next("%dict"))
-
-          val convertedArgs = allArgs.map(bindToName(_, None))
-          val argOps        = convertedArgs.map(_.value).mkString(", ")
-          Emitted(
-            convertedArgs.flatMap(_.code).toVector ++ Vector(
-              s"$binding = sdql.create_dictionary $argOps : $argTypes -> $resultTyp"
-            ),
-            binding
-          )
-
-        case Get(e1: Exp, e2: Exp) =>
-          val where = bindToName(e1, None)
-
-          val what = bindToName(e2, None)
-
-          val binding = desired.getOrElse(fresh.next("%get"))
-
-          TypeInference.run(e1) match {
-            case recType: RecordType =>
-              // %val = sdql.access_record %rec "a" : record<"a": i32, "b": f32> -> i32
-              val res = s"$binding = sdql.access_record ${where.value} \"${what.value}\" : ${recType.attrs
-                  .map(attr => s"${attr.name}: ${mlirType(attr.tpe)}")
-                  .mkString("record<", ", ", ">")}"
-              Emitted(where.code ++ what.code ++ Vector(res), binding)
-            case dictType: DictType  =>
-              // ex: %val = sdql.lookup_dictionary %dict [%key : i32] : dictionary<i32, f16> -> f16
-              val res = s"$binding = sdql.lookup_dictionary ${where.value} [${what.value} : ${mlirType(
-                  TypeInference.run(e2)
-                )}] : ${mlirType(dictType)} -> ${mlirType(dictType.value)}"
-              Emitted(where.code ++ what.code ++ Vector(res), binding)
-            case x                   =>
-              raise(f"unhandled lookup on type ${x.prettyPrint} in MlirCodegen.bindToName()")
-          }
-
-        case Load(_: String, _: Type, _: DictNode)         =>
-          val binding = desired.getOrElse(fresh.next("%load"))
-          Emitted(Vector(s"$binding = load shananigans"), binding)
-
-        // sum (x in e1) body
-
-        // %0 = sdql.empty_dictionary : dictionary<i32, f16>
-
-        // %1 = sdql.sum %0 : dictionary<i32, f16> -> f16 {
-        // ^bb0(%x: record<"key": i32, "value": f16>):
-        //   %tmp = sdql.access_record %x "value" : record<"key": i32, "value": f16> -> f16
-        //   sdql.yield %tmp : f16
-        // }
-        case Sum(key: Sym, value: Sym, e1: Exp, body: Exp) =>
-          // key and value present in body but not in e1
-          val e1Evaled = bindToName(e1, None)
-
-          val binding = desired.getOrElse(fresh.next("%sum"))
-
-          val prefix = s"$binding = sdql.sum ${e1Evaled.value} : ${mlirType(TypeInference.run(e1))}"
-
-          // result type? its type of body assuming proper binding key and value
-          val extendedCtx = TypeInference.run(e1) match {
-            case DictType(dictKey: Type, dictVal: Type, _) =>
-              ctx ++ Map(key -> dictKey, value -> dictVal)
-            case x                                         =>
-              raise(f"unhandled sum on type ${x.prettyPrint} in MlirCodegen.bindToName()")
-          }
-
-          val retType = mlirType(TypeInference.run(body)(extendedCtx))
-
-          val blockDecl =
-            s"${fresh.next("^bb")}(%${key.name}: ${mlirType(extendedCtx.get(key).get)}, %${value.name}: ${mlirType(extendedCtx.get(value).get)}):"
-          val blockBody = bindToName(body, None)(extendedCtx)
-          val blockRet  = s"  sdql.yield ${blockBody.value} : ${retType}"
-
-          // here we assume result of aggregation of elements of type retType is retType
-          val newOp = Vector(s"$prefix -> $retType {") ++ Vector(blockDecl) ++ blockBody.code.map("  " + _) ++ Vector(
-            blockRet
-          ) ++ Vector("}")
-          Emitted(e1Evaled.code ++ newOp, "binding")
-
-        // %res = sdql.create_record {fields = ["a", "b"]} %0, %1 : i32, f32 -> record<"a": i32, "b": f32>
-        case RecNode(values)                               =>
-          val fieldTypes = values.map(_._2).map(TypeInference.run(_))
-          val fieldNames = values.map(_._1)
-
-          val computedFields     = values.map(_._2).map(bindToName(_, None))
-          val computedFieldTypes = fieldTypes.map(mlirType(_))
-
-          val binding = desired.getOrElse(fresh.next("%recnode"))
-
-          val fieldsAttr = s"{fields = ${fieldNames.map(name => s"\"$name\"").mkString("[", ", ", "]")}}"
-
-          val retTypeFields = values
-            .map(field => s"\"${field._1}\": ${mlirType(TypeInference.run(field._2))}")
-            .mkString("record<", ", ", ">")
-
-          val op =
-            s"$binding = sdql.create_record $fieldsAttr ${computedFields.map(_.value).mkString(", ")} : ${computedFieldTypes
-                .mkString(", ")} -> $retTypeFields"
-          Emitted(computedFields.flatMap(_.code).toVector ++ Vector(op), binding)
-
-        // %val = sdql.access_record %rec "a" : record<"a": i32, "b": f32> -> i32
-        case FieldNode(e: Exp, f: String)                  =>
-          val inType            = TypeInference.run(e) match {
-            case x @ RecordType(_) => x
-            case x @ _             => raise(f"unhandled field access on type ${x.prettyPrint} in MlirCodegen.bindToName()")
-          }
-          val accessedFieldType = inType.attrs.find(_.name == f) match {
-            case Some(attr) => attr.tpe
-            case None       =>
-              raise(
-                f"unhandled field access due to missing field $f in ${inType.prettyPrint} in MlirCodegen.bindToName()"
-              )
-          }
-          val retTypeFields     =
-            inType.attrs.map(field => s"\"${field.name}\": ${mlirType(field.tpe)}").mkString("record<", ", ", ">")
-
-          val compE = bindToName(e, None)
-
-          val binding = desired.getOrElse(fresh.next("%fieldnode"))
-
-          val op =
-            s"$binding = sdql.access_record ${compE.value} \"$f\" : $retTypeFields -> ${mlirType(accessedFieldType)} "
-
-          Emitted(compE.code ++ Vector(op), binding)
-
-        // %0 = "func.call"(%1) <{callee = @range_builtin}> : (i32) -> dictionary<i32, i1>
-        case RangeNode(e: Exp)                             =>
-          val compE   = bindToName(e, None)
-          val binding = desired.getOrElse(fresh.next("%rangenode"))
-          val typ     = mlirType(TypeInference.run(e))
-
-          val op =
-            s"$binding = \"func.call\"(${compE.value}) <{callee = @range_builtin}> : ($typ) -> dictionary<$typ, i32>"
-          Emitted(compE.code ++ Vector(op), binding)
-
-        /*
-    %res = "scf.if"(%cond) ({
-        %mul = "arith.mulf"(%l_extendedprice, %l_discount) <{"fastmath" = #arith.fastmath<none>}> : (f64, f64) -> f64
-        "scf.yield"(%mul) : (f64) -> ()
-    }, {
-        %zero = "arith.constant"() <{value = 0.0 : f64}> : () -> f64
-        "scf.yield"(%zero) : (f64) -> ()
-    }) : (i1) -> f64
-         */
-        case IfThenElse(cond, thenp, elsep)                =>
-          val outT = mlirType(TypeInference.run(x))
-
-          val c    = bindToName(cond, None)
-          val cTyp = mlirType(TypeInference.run(cond))
-
-          val t    = bindToName(thenp, None)
-          val tTyp = mlirType(TypeInference.run(thenp))
-
-          // val eTyp = mlirType(TypeInference.run(elsep))
-          val e = bindToName(elsep, None, Some(TypeInference.run(x)))
-
-          val binding = desired.getOrElse(fresh.next("%if"))
-          val code    = c.code ++
-            Vector(s"$binding = \"scf.if\"(${c.value}) ({") ++
-            t.code.map("  " + _) ++
-            Vector(s"  \"scf.yield\"(${t.value}) : ($tTyp) -> ()") ++
-            Vector("}, {") ++
-            e.code.map("  " + _) ++
-            Vector(s"  \"scf.yield\"(${e.value}) : (${tTyp}) -> ()") ++
-            Vector(s"}) : ($cTyp) -> $outT")
-          Emitted(code, binding)
-
-        case Cmp(e1, e2, cmp) if (e2.isInstanceOf[DictNode] && e2.asInstanceOf[DictNode].map == Nil) =>
-          // is it always i1?
-          val outT = mlirType(TypeInference.run(x))
-
-          val predicateVal = cmp match {
-            // https://mlir.llvm.org/docs/Dialects/ArithOps/#cmpfpredicate
-            case "<=" => 5
-            case "<"  => 4
-            case "!=" => 6
-          }
-          val comp1        = bindToName(e1, None)
-          val type1        = TypeInference.run(e1)
-          val t1           = mlirType(type1)
-          val comp2        = bindToName(e2, None, Some(type1))
-          val t2           = t1
-
-          val binding = desired.getOrElse(fresh.next("%cmpf"))
-
-          val op =
-            s"$binding = \"arith.cmpf\"(${comp1.value}, ${comp2.value}) <{fastmath = #arith.fastmath<none>, predicate = $predicateVal}> : ($t1, $t2) -> $outT"
-          Emitted(comp1.code ++ comp2.code ++ Vector(op), binding)
-
-        // %2 = "arith.cmpi"(%0, %1) <{predicate = 3}> : (i32, i32) -> i1
-        case Cmp(e1, e2, cmp)
-            if (TypeInference.run(e1) == IntType || TypeInference
-              .run(e1) == LongType || TypeInference.run(e1) == DateType) &&
-              (TypeInference.run(e2) == IntType || TypeInference
-                .run(e2) == LongType || TypeInference.run(e2) == DateType) =>
-          // is it always i1?
-          val outT = mlirType(TypeInference.run(x))
-
-          val predicateVal = cmp match {
-            // https://mlir.llvm.org/docs/Dialects/ArithOps/#cmpipredicate
-            case "<=" => 3
-            case "<"  => 2
-            case "==" => 0
-            case "!=" => 1
-          }
-          val comp1        = bindToName(e1, None)
-          val t1           = mlirType(TypeInference.run(e1))
-          val comp2        = bindToName(e2, None)
-          val t2           = mlirType(TypeInference.run(e2))
-
-          val binding = desired.getOrElse(fresh.next("%cmpi"))
-
-          val op =
-            s"$binding = \"arith.cmpi\"(${comp1.value}, ${comp2.value}) <{predicate = $predicateVal}> : ($t1, $t2) -> $outT"
-          Emitted(comp1.code ++ comp2.code ++ Vector(op), binding)
-
-        case Cmp(e1, e2, cmp) if (TypeInference.run(e1) == RealType || TypeInference.run(e1) == RealType) =>
-          // is it always i1?
-          val outT = mlirType(TypeInference.run(x))
-
-          val predicateVal = cmp match {
-            // https://mlir.llvm.org/docs/Dialects/ArithOps/#cmpfpredicate
-            case "<=" => 5
-            case "<"  => 4
-            case "!=" => 6
-            case "==" => 1
-          }
-          val comp1        = bindToName(e1, None)
-          val t1           = mlirType(TypeInference.run(e1))
-          val comp2        = bindToName(e2, None)
-          val t2           = mlirType(TypeInference.run(e2))
-
-          val binding = desired.getOrElse(fresh.next("%cmpf"))
-
-          val op =
-            s"$binding = \"arith.cmpf\"(${comp1.value}, ${comp2.value}) <{fastmath = #arith.fastmath<none>, predicate = $predicateVal}> : ($t1, $t2) -> $outT"
-          Emitted(comp1.code ++ comp2.code ++ Vector(op), binding)
-
-        // %a = arith.muli %b, %c : i64
-        case Mult(e1, e2)
-            if (TypeInference.run(e1) == IntType || TypeInference.run(e1) == LongType) &&
-              (TypeInference.run(e2) == IntType || TypeInference.run(e2) == LongType) =>
-          val outT = mlirType(TypeInference.run(x))
-
-          val binding = desired.getOrElse(fresh.next("%multi"))
-
-          val comp1 = bindToName(e1, None)
-          val t1    = mlirType(TypeInference.run(e1))
-          val comp2 = bindToName(e2, None)
-          val t2    = mlirType(TypeInference.run(e2))
-
-          val op = s"$binding = \"arith.muli\"(${comp1.value}, ${comp2.value}) : ($t1, $t2) -> $outT"
-          Emitted(comp1.code ++ comp2.code ++ Vector(op), binding)
-
-        case Mult(e1, e2) if TypeInference.run(e1) == RealType || TypeInference.run(e2) == RealType =>
-          val outT = mlirType(TypeInference.run(x))
-
-          val binding = desired.getOrElse(fresh.next("%multf"))
-
-          val comp1 = bindToName(e1, None)
-          val t1    = mlirType(TypeInference.run(e1))
-          val comp2 = bindToName(e2, None)
-          val t2    = mlirType(TypeInference.run(e2))
-
-          val op =
-            s"$binding = \"arith.mulf\"(${comp1.value}, ${comp2.value}) <{fastmath = #arith.fastmath<none>}> : ($t1, $t2) -> $outT"
-          Emitted(comp1.code ++ comp2.code ++ Vector(op), binding)
-
-        case Add(e1, e2) if List(IntType, LongType).contains(TypeInference.run(e1)) =>
-          val outT = mlirType(TypeInference.run(x))
-
-          val binding = desired.getOrElse(fresh.next("%addi"))
-
-          val comp1 = bindToName(e1, None)
-          val t1    = mlirType(TypeInference.run(e1))
-          val comp2 = bindToName(e2, None)
-          val t2    = mlirType(TypeInference.run(e2))
-
-          val op = s"$binding = \"arith.addi\"(${comp1.value}, ${comp2.value}) : ($t1, $t2) -> $outT"
-          Emitted(comp1.code ++ comp2.code ++ Vector(op), binding)
-
-        case Add(e1, e2) if TypeInference.run(e1) == RealType =>
-          val outT = mlirType(TypeInference.run(x))
-
-          val binding = desired.getOrElse(fresh.next("%addf"))
-
-          val comp1 = bindToName(e1, None)
-          val t1    = mlirType(TypeInference.run(e1))
-          val comp2 = bindToName(e2, None)
-          val t2    = mlirType(TypeInference.run(e2))
-
-          val op =
-            s"$binding = \"arith.addf\"(${comp1.value}, ${comp2.value}) <{fastmath = #arith.fastmath<none>}> : ($t1, $t2) -> $outT"
-          Emitted(comp1.code ++ comp2.code ++ Vector(op), binding)
-
-        case Neg(e) if TypeInference.run(e) == BoolType                       =>
-          val zero   = desired.getOrElse(fresh.next("%zero"))
-          val zeroOp = s"$zero = \"arith.constant\"() <{value = 0 : i1}> : () -> i1"
-
-          // val res = s"$binding = \"arith.constant\"() <{value = $v : i32}> : () -> i32"
-
-          val binding = desired.getOrElse(fresh.next("%neg"))
-
-          val comp = bindToName(e, None)
-          val op   = s"$binding = \"arith.cmpi\"(${comp.value}, $zero) <{predicate = 0}> : (i1, i1) -> i1"
-          Emitted(comp.code ++ Vector(zeroOp, op), comp.value)
-        case Neg(e) if List(IntType, LongType).contains(TypeInference.run(e)) =>
-          val binding = desired.getOrElse(fresh.next("%addf"))
-
-          val comp = bindToName(e, None)
-          val t    = mlirType(TypeInference.run(e))
-
-          val zero   = desired.getOrElse(fresh.next("%zero"))
-          val zeroOp = s"$zero = \"arith.constant\"() <{value = 0 : $t}> : () -> $t"
-
-          val op = s"$binding = \"arith.subi\"($zero, ${comp.value}) : ($t, $t) -> $t"
-          Emitted(comp.code ++ Vector(zeroOp) ++ Vector(op), binding)
-        case Neg(e) if TypeInference.run(e) == RealType                       =>
-          val binding = desired.getOrElse(fresh.next("%addf"))
-
-          val comp = bindToName(e, None)
-          val t    = mlirType(TypeInference.run(e))
-
-          val zero   = desired.getOrElse(fresh.next("%zero"))
-          val zeroOp = s"$zero = \"arith.constant\"() <{value = 0 : $t}> : () -> $t"
-
-          val op =
-            s"$binding = \"arith.subf\"($zero, ${comp.value}) <{fastmath = #arith.fastmath<none>}> : ($t, $t) -> $t"
-          Emitted(comp.code ++ Vector(zeroOp) ++ Vector(op), binding)
-
-        case Concat(e1, e2)
-            if TypeInference.run(e1).isInstanceOf[RecordType] && TypeInference.run(e2).isInstanceOf[RecordType] =>
-          val outT = TypeInference.run(x)
-
-          val typ1 = mlirType(TypeInference.run(e1))
-          val typ2 = mlirType(TypeInference.run(e2))
-
-          val gen1 = bindToName(e1, None)
-          val gen2 = bindToName(e2, None)
-
-          val binding = desired.getOrElse(fresh.next("%concat"))
-
-          val op = s"$binding = sdql.concat ${gen1.value}, ${gen2.value} : $typ1, $typ2 -> $outT"
-          Emitted(gen1.code ++ gen2.code ++ Vector(op), binding)
-
-        case External(name, args) =>
-          val outT = TypeInference.run(x)
-
-          val generated = args.map(bindToName(_, None))
-          val types     = args.map(TypeInference.run)
-          println(s"name=$name, types=$types")
-          val binding   = desired.getOrElse(fresh.next("%external"))
-
-          val op =
-            s"$binding = sdql.external $name, ${generated.map(_.value).mkString(", ")} : ${types.map(mlirType)}} : ${mlirType(outT)}"
-          Emitted(generated.flatMap(_.code).toVector ++ Vector(op), binding)
-
-        case Cmp(e1, e2, cmp) if cmp == "==" =>
-          val outT = TypeInference.run(x)
-
-          val typ1 = mlirType(TypeInference.run(e1))
-          val typ2 = e2 match {
-            // workaround for `a != { }`
-            case DictNode(Nil, _) => typ1
-            case _                => mlirType(TypeInference.run(e2))
-          }
-
-          val gen1 = bindToName(e1, None)
-          // workaround for a != { }
-          val gen2 = bindToName(e2, None, expected = Some(TypeInference.run(e1)))
-
-          val binding = desired.getOrElse(fresh.next("%cmp"))
-
-          val op = s"$binding = sdql.cmp ${gen1.value}, ${gen2.value} : $typ1, $typ2 -> $outT"
-          Emitted(gen1.code ++ gen2.code ++ Vector(op), binding)
-
-        case Cmp(e1, e2, cmp) if cmp == "!=" =>
-          val negated = Cmp(e1, e2, "==")
-          bindToName(Neg(negated), desired, expected)
-
-        case Unique(_) =>
-          println("unique... " + TypeInference.run(x).prettyPrint)
-          Emitted(Vector.empty, "")
-
-        case _ =>
-          raise("¯\\_(ツ)_/¯ " + x)
-      }
-
-    bindToName(e, None)(Map.empty)
+    builder.result
   }
+
+  def bindToName(x: Exp, desired: Option[String], expectedType: Option[Type] = None)(implicit
+    ctx: TypesCtx,
+    builder: MlirBuilder
+  ): V =
+    x match {
+      // let x = e1 in e2
+      case LetBinding(x @ Sym(name), e1, e2) =>
+        val boundName = s"%$name"
+        val rhs       = bindToName(e1, desired = Some(boundName), expectedType = None)
+
+        val ctx2 = ctx ++ Map(x -> rhs.typ)
+        bindToName(e2, desired = None, expectedType = None)(ctx2, builder)
+
+      case sym @ Sym(name) =>
+        val tpe = ctx.getOrElse(sym, raise(s"unknown name for symbol: $sym"))
+        V(s"%$name", tpe)
+
+      case Const(v: Int) =>
+        val name = desired.getOrElse(builder.fresh("%consti"))
+        builder.line(s"$name = \"arith.constant\"() <{value = $v : i32}> : () -> i32")
+        V(name, IntType)
+      // type of cmp is the same as type of result! no need to look at args
+
+      case Const(v: Double) =>
+        val name = desired.getOrElse(builder.fresh("%constd"))
+        builder.line(s"$name = \"arith.constant\"() <{value = $v : f64}> : () -> f64")
+        V(name, RealType)
+
+      case Const(v: Boolean)   =>
+        val name = desired.getOrElse(builder.fresh("%constv"))
+        builder.line(s"$name = \"arith.constant\"() <{value = ${if (v) 1 else 0} : i1}> : () -> i1")
+        V(name, BoolType)
+
+      // TODO: what's mlir handling of date? for now its i32
+      case Const(v: DateValue) =>
+        val name = desired.getOrElse(builder.fresh("%constda"))
+        builder.line(s"$name = \"arith.constant\"() <{value = ${v.v} : i32}> : () -> i32")
+        V(name, DateType)
+
+      case Const(v: String)                             =>
+        val name = desired.getOrElse(builder.fresh("%constds"))
+        // StringType(Some(maxLen: Int)) or StringType(None)
+        val tpe  = TypeInference.run(x)
+
+        builder.line(s"// $v")
+        // TODO: handle encoding stuff
+        builder.line(
+          s"$name = \"arith.constant\"() <{value = dense<${v.getBytes().mkString("[", ", ", "]")}}> : () -> memref<${v.size}xi1>"
+        )
+        V(name, tpe)
+
+      // ex: %dict = sdql.empty_dictionary : dictionary<i32, f16>
+      case DictNode(Nil, _)                             =>
+        expectedType match {
+          case Some(typ) =>
+            val name = desired.getOrElse(builder.fresh("%dict"))
+            builder.line(s"$name = sdql.empty_dictionary : ${mlirType(typ)}")
+            V(name, typ)
+          case None      =>
+            raise("empty dictionary needs expected DictType")
+        }
+
+      // ex: %8 = sdql.create_dictionary %5, %7 : i32, i1 -> dictionary<i32, i1>
+      case DictNode(args: Seq[(Exp, Exp)], _: DictHint) =>
+        val name = desired.getOrElse(builder.fresh("%dict"))
+
+        val resultTyp = TypeInference.run(x)(ctx)
+
+        // Seq of all args (keys and values)
+        val allArgs     = args.flatMap { case (key, value) => Seq(key, value) }
+        // types of arg list
+        val argTypes    = allArgs
+          .map(argTyp => mlirType(TypeInference.run(argTyp)(ctx)))
+          .mkString(", ")
+        // compute arguments and retrieve names
+        val computeArgs = allArgs.map(bindToName(_, None))
+
+        val argOps = computeArgs.map(_.name).mkString(", ")
+        builder.line(s"$name = sdql.create_dictionary $argOps : $argTypes -> ${mlirType(resultTyp)}")
+        V(name, resultTyp)
+
+      case Get(e1: Exp, e2: Exp) =>
+        val name      = desired.getOrElse(builder.fresh("%get"))
+        val resultTyp = TypeInference.run(x)(ctx)
+
+        val where = bindToName(e1, None, None)
+        val what  = bindToName(e2, None, None)
+
+        where.typ match {
+          case d: DictType   =>
+            builder.line(
+              s"$name = sdql.lookup_dictionary ${where.name} [${what.name} : ${mlirType(what.typ)}] : ${mlirType(d)} -> ${mlirType(resultTyp)}"
+            )
+          case r: RecordType =>
+            builder.line(
+              s"$name = sdql.access_record ${where.name} \"${what.name}\" : ${mlirType(r)} -> ${mlirType(resultTyp)}"
+            )
+          case x             => raise("dictionary expected on lhs of get, instead got: " + x.simpleName)
+        }
+        V(name, resultTyp)
+
+      // ex: %val = sdql.lookup_dictionary %dict [%key : i32] : dictionary<i32, f16> -> f16
+
+      case Load(path: String, typ: Type, _: DictNode)                                            =>
+        // TODO: handle skiplist
+        val name = desired.getOrElse(builder.fresh("%load"))
+        builder.line(s"$name = sdql.load \"$path\" : ${mlirType(typ)}")
+        V(name, TypeInference.run(x))
+
+      // sum (x in e1) body
+
+      // %0 = sdql.empty_dictionary : dictionary<i32, f16>
+
+      // %1 = sdql.sum %0 : dictionary<i32, f16> -> f16 {
+      // ^bb0(%x: record<"key": i32, "value": f16>):
+      //   %tmp = sdql.access_record %x "value" : record<"key": i32, "value": f16> -> f16
+      //   sdql.yield %tmp : f16
+      // }
+      case Sum(key: Sym, value: Sym, e1: Exp, body: Exp)                                         =>
+        // key and value present in body but not in e1
+        val e1Evaled = bindToName(e1, None, None)
+
+        val name    = desired.getOrElse(builder.fresh("%sum"))
+        val retType = TypeInference.run(x)
+        builder.line(s"$name = sdql.sum ${e1Evaled.name} : ${mlirType(e1Evaled.typ)} -> ${mlirType(retType)} {")
+
+        // result type? its type of body assuming proper binding key and value
+        val extendedCtx = TypeInference.run(e1) match {
+          case DictType(dictKey: Type, dictVal: Type, _) =>
+            ctx ++ Map(key -> dictKey, value -> dictVal)
+          case x                                         =>
+            raise(f"unhandled sum on type ${x.prettyPrint} in MlirCodegen.bindToName()")
+        }
+
+        val bodyRetTyp = TypeInference.run(body)(extendedCtx)
+
+        val blockName = builder.fresh("^bb")
+        builder.line(
+          s"${blockName}(%${key.name}: ${mlirType(extendedCtx.get(key).get)}, %${value.name}: ${mlirType(extendedCtx.get(value).get)}):"
+        )
+        builder.withIndent {
+          val blockBody = bindToName(body, None, None)(extendedCtx, builder)
+          builder.line(s"sdql.yield ${blockBody.name} : ${mlirType(bodyRetTyp)}")
+        }
+        builder.line("}")
+        V(name, retType)
+
+      // %res = sdql.create_record {fields = ["a", "b"]} %0, %1 : i32, f32 -> record<"a": i32, "b": f32>
+      case RecNode(values)                                                                       =>
+        val fieldTypes = values.map(_._2).map(TypeInference.run(_))
+        val fieldNames = values.map(_._1)
+
+        val computedFields     = values.map(_._2).map(bindToName(_, None))
+        val computedFieldTypes = fieldTypes.map(mlirType(_))
+
+        val name = desired.getOrElse(builder.fresh("%recnode"))
+
+        val fieldsAttr = s"{fields = ${fieldNames.map(name => s"\"$name\"").mkString("[", ", ", "]")}}"
+
+        val retTypeFields = values
+          .map(field => s"\"${field._1}\": ${mlirType(TypeInference.run(field._2))}")
+          .mkString("record<", ", ", ">")
+
+        builder.line(
+          s"$name = sdql.create_record $fieldsAttr ${computedFields.map(_.name).mkString(", ")} : ${computedFieldTypes
+              .mkString(", ")} -> $retTypeFields"
+        )
+        V(name, TypeInference.run(x))
+
+      // %val = sdql.access_record %rec "a" : record<"a": i32, "b": f32> -> i32
+      case FieldNode(e: Exp, f: String)                                                          =>
+        val inType            = TypeInference.run(e) match {
+          case x @ RecordType(_) => x
+          case x @ _             => raise(f"unhandled field access on type ${x.prettyPrint} in MlirCodegen.bindToName()")
+        }
+        val accessedFieldType = inType.attrs.find(_.name == f) match {
+          case Some(attr) => attr.tpe
+          case None       =>
+            raise(
+              f"unhandled field access due to missing field $f in ${inType.prettyPrint} in MlirCodegen.bindToName()"
+            )
+        }
+        val retTypeFields     =
+          inType.attrs.map(field => s"\"${field.name}\": ${mlirType(field.tpe)}").mkString("record<", ", ", ">")
+
+        val compE = bindToName(e, None)
+
+        val name = desired.getOrElse(builder.fresh("%fieldnode"))
+        builder.line(
+          s"$name = sdql.access_record ${compE.name} \"$f\" : $retTypeFields -> ${mlirType(accessedFieldType)}"
+        )
+
+        V(name, accessedFieldType)
+
+      // %0 = "func.call"(%1) <{callee = @range_builtin}> : (i32) -> dictionary<i32, i1>
+      case RangeNode(e: Exp)                                                                     =>
+        val compE = bindToName(e, None)
+        val name  = desired.getOrElse(builder.fresh("%rangenode"))
+        val typ   = TypeInference.run(e)
+
+        builder.line(
+          s"$name = \"func.call\"(${compE.name}) <{callee = @range_builtin}> : (${mlirType(typ)}) -> dictionary<${mlirType(typ)}, i32>"
+        )
+        V(name, TypeInference.run(x))
+
+      /*
+  %res = "scf.if"(%cond) ({
+      ...
+      "scf.yield"(%mul) : (f64) -> ()
+  }, {
+      ...
+      "scf.yield"(%zero) : (f64) -> ()
+  }) : (i1) -> f64
+       */
+      case IfThenElse(cond, thenp, elsep)                                                        =>
+        // compute result type
+        val outTyp = TypeInference.run(x)
+
+        // lower the condition
+        val c = bindToName(cond, None)
+        if (c.typ != BoolType) {
+          raise(s"condition in IfThenElse must be of type BoolType, got ${c.typ.prettyPrint}")
+        }
+
+        val name = desired.getOrElse(builder.fresh("%if"))
+
+        // emit if header
+        builder.line(s"$name = \"scf.if\"(${c.name}) ({")
+
+        // emit then branch
+        builder.withIndent {
+          val thenBranch = bindToName(thenp, desired = None, expectedType = Some(outTyp))
+          builder.line(s"\"scf.yield\"(${thenBranch.name}) : (${mlirType(outTyp)} -> ()")
+        }
+        builder.line("}, {")
+
+        // emit else branch
+        builder.withIndent {
+          val elseBranch = bindToName(elsep, desired = None, expectedType = Some(outTyp))
+          builder.line(s"\"scf.yield\"(${elseBranch.name}) : (${mlirType(outTyp)} -> ()")
+        }
+
+        builder.line(s"}) : (i1) -> ${mlirType(outTyp)}")
+        V(name, outTyp)
+
+      // %2 = "arith.cmpi"(%0, %1) <{predicate = 3}> : (i32, i32) -> i1
+      case Cmp(e1, e2, cmp) if List(IntType, LongType, DateType).contains(TypeInference.run(e1)) =>
+        val outTyp = TypeInference.run(x)
+        val outT   = mlirType(outTyp)
+
+        val predicateVal = cmp match {
+          // https://mlir.llvm.org/docs/Dialects/ArithOps/#cmpipredicate
+          case "<=" => 3
+          case "<"  => 2
+          case "==" => 0
+          case "!=" => 1
+        }
+        val comp1        = bindToName(e1, None)
+        val typ1         = TypeInference.run(e1)
+        val t1           = mlirType(typ1)
+        val comp2        = bindToName(e2, None, Some(typ1))
+        val t2           = mlirType(comp2.typ)
+
+        val name = desired.getOrElse(builder.fresh("%cmpi"))
+
+        builder.line(
+          s"$name = \"arith.cmpi\"(${comp1.name}, ${comp2.name}) <{predicate = $predicateVal}> : ($t1, $t2) -> $outT"
+        )
+        V(name, outTyp)
+
+      case Cmp(e1, e2, cmp) if TypeInference.run(e1) == RealType                            =>
+        // is it always i1?
+        val outTyp = TypeInference.run(x)
+        val outT   = mlirType(outTyp)
+
+        val predicateVal = cmp match {
+          // https://mlir.llvm.org/docs/Dialects/ArithOps/#cmpfpredicate
+          case "<=" => 5
+          case "<"  => 4
+          case "!=" => 6
+          case "==" => 1
+        }
+        val comp1        = bindToName(e1, None)
+        val typ1         = TypeInference.run(e1)
+        val t1           = mlirType(typ1)
+        val comp2        = bindToName(e2, None, Some(typ1))
+        val t2           = mlirType(comp2.typ)
+
+        val name = desired.getOrElse(builder.fresh("%cmpf"))
+
+        builder.line(
+          s"$name = \"arith.cmpf\"(${comp1.name}, ${comp2.name}) <{fastmath = #arith.fastmath<none>, predicate = $predicateVal}> : ($t1, $t2) -> $outT"
+        )
+        V(name, outTyp)
+
+      // %a = arith.muli %b, %c : i64
+      case Mult(e1, e2) if List(IntType, LongType, DateType).contains(TypeInference.run(x)) =>
+        val outTyp = TypeInference.run(x)
+        val outT   = mlirType(outTyp)
+
+        val name = desired.getOrElse(builder.fresh("%multi"))
+
+        val comp1 = bindToName(e1, None)
+        val t1    = mlirType(TypeInference.run(e1))
+        val comp2 = bindToName(e2, None)
+        val t2    = mlirType(TypeInference.run(e2))
+
+        builder.line(s"$name = \"arith.muli\"(${comp1.name}, ${comp2.name}) : ($t1, $t2) -> $outT")
+        V(name, outTyp)
+
+      case Mult(e1, e2) if TypeInference.run(x) == RealType =>
+        val outTyp = TypeInference.run(x)
+        val outT   = mlirType(outTyp)
+
+        val name = desired.getOrElse(builder.fresh("%multf"))
+
+        val comp1 = bindToName(e1, None)
+        val t1    = mlirType(TypeInference.run(e1))
+        val comp2 = bindToName(e2, None)
+        val t2    = mlirType(TypeInference.run(e2))
+
+        builder.line(
+          s"$name = \"arith.mulf\"(${comp1.name}, ${comp2.name}) <{fastmath = #arith.fastmath<none>}> : ($t1, $t2) -> $outT"
+        )
+        V(name, outTyp)
+
+      case Add(e1, e2) if List(IntType, LongType).contains(TypeInference.run(e1)) =>
+        val outTyp = TypeInference.run(x)
+        val outT   = mlirType(outTyp)
+
+        val name = desired.getOrElse(builder.fresh("%addi"))
+
+        val comp1 = bindToName(e1, None)
+        val t1    = mlirType(TypeInference.run(e1))
+        val comp2 = bindToName(e2, None)
+        val t2    = mlirType(TypeInference.run(e2))
+
+        builder.line(s"$name = \"arith.addi\"(${comp1.name}, ${comp2.name}) : ($t1, $t2) -> $outT")
+        V(name, outTyp)
+
+      case Add(e1, e2) if TypeInference.run(e1) == RealType =>
+        val outTyp = TypeInference.run(x)
+        val outT   = mlirType(outTyp)
+
+        val name = desired.getOrElse(builder.fresh("%addf"))
+
+        val comp1 = bindToName(e1, None)
+        val t1    = mlirType(TypeInference.run(e1))
+        val comp2 = bindToName(e2, None)
+        val t2    = mlirType(TypeInference.run(e2))
+
+        builder.line(
+          s"$name = \"arith.addf\"(${comp1.name}, ${comp2.name}) <{fastmath = #arith.fastmath<none>}> : ($t1, $t2) -> $outT"
+        )
+        V(name, outTyp)
+
+      case Neg(e) if TypeInference.run(e) == BoolType =>
+        val zero = desired.getOrElse(builder.fresh("%zero"))
+
+        // val res = s"$name = \"arith.constant\"() <{value = $v : i32}> : () -> i32"
+
+        val name = desired.getOrElse(builder.fresh("%neg"))
+
+        val comp = bindToName(e, None)
+        builder.line(s"$zero = \"arith.constant\"() <{value = 0 : i1}> : () -> i1")
+
+        builder.line(s"$name = \"arith.cmpi\"(${comp.name}, $zero) <{predicate = 0}> : (i1, i1) -> i1")
+        V(name, BoolType)
+
+      case Neg(e) if List(IntType, LongType).contains(TypeInference.run(e)) =>
+        val outTyp = TypeInference.run(x)
+        val name   = desired.getOrElse(builder.fresh("%negi"))
+
+        val comp = bindToName(e, None)
+        val t    = mlirType(outTyp)
+
+        val zero = desired.getOrElse(builder.fresh("%zero"))
+        builder.line(s"$zero = \"arith.constant\"() <{value = 0 : $t}> : () -> $t")
+
+        builder.line(s"$name = \"arith.subi\"($zero, ${comp.name}) : ($t, $t) -> $t")
+        V(name, outTyp)
+
+      case Neg(e) if TypeInference.run(x) == RealType =>
+        val name = desired.getOrElse(builder.fresh("%negf"))
+
+        val comp = bindToName(e, None)
+        val t    = mlirType(TypeInference.run(e))
+
+        val zero = desired.getOrElse(builder.fresh("%zero"))
+        builder.line(s"$zero = \"arith.constant\"() <{value = 0 : $t}> : () -> $t")
+
+        builder.line(
+          s"$name = \"arith.subf\"($zero, ${comp.name}) <{fastmath = #arith.fastmath<none>}> : ($t, $t) -> $t"
+        )
+        V(name, RealType)
+
+      case Concat(e1, e2)
+          if TypeInference.run(e1).isInstanceOf[RecordType] && TypeInference.run(e2).isInstanceOf[RecordType] =>
+        val outTyp = TypeInference.run(x)
+
+        val typ1 = mlirType(TypeInference.run(e1))
+        val typ2 = mlirType(TypeInference.run(e2))
+
+        val gen1 = bindToName(e1, None)
+        val gen2 = bindToName(e2, None)
+
+        val name = desired.getOrElse(builder.fresh("%concat"))
+
+        builder.line(s"$name = sdql.concat ${gen1.name}, ${gen2.name} : $typ1, $typ2 -> ${mlirType(outTyp)}")
+        V(name, outTyp)
+
+      case External(extName, args) =>
+        val outT = TypeInference.run(x)
+
+        val generated = args.map(bindToName(_, None))
+        val types     = args.map(TypeInference.run)
+
+        val name = desired.getOrElse(builder.fresh("%external"))
+
+        builder.line(
+          s"$name = sdql.external $extName, ${generated.map(_.name).mkString(", ")} : ${types.map(mlirType)}} : ${mlirType(outT)}"
+        )
+        V(name, outT)
+
+      case Cmp(e1, e2, cmp) if cmp == "==" =>
+        val outTyp = TypeInference.run(x)
+
+        val typ1 = mlirType(TypeInference.run(e1))
+        val typ2 = e2 match {
+          // workaround for `a != { }`
+          case DictNode(Nil, _) => typ1
+          case _                => mlirType(TypeInference.run(e2))
+        }
+
+        val gen1 = bindToName(e1, None)
+        // workaround for a != { }
+        val gen2 = bindToName(e2, None, expectedType = Some(TypeInference.run(e1)))
+
+        val name = desired.getOrElse(builder.fresh("%cmp"))
+
+        builder.line(s"$name = sdql.cmp ${gen1.name}, ${gen2.name} : $typ1, $typ2 -> ${mlirType(outTyp)}")
+        V(name, outTyp)
+
+      case Cmp(e1, e2, cmp) if cmp == "!=" =>
+        val negated = Cmp(e1, e2, "==")
+        bindToName(Neg(negated), desired, expectedType)
+
+      case Unique(_) =>
+        println("unique... " + TypeInference.run(x).prettyPrint)
+        V("1", TypeInference.run(x))
+
+      case _ =>
+        raise("¯\\_(ツ)_/¯ " + x)
+    }
 }

--- a/src/main/scala/sdql/backend/MlirCodegen.scala
+++ b/src/main/scala/sdql/backend/MlirCodegen.scala
@@ -1,0 +1,374 @@
+package sdql.backend
+
+import sdql.analysis.TypeInference
+import sdql.ir.*
+import sdql.raise
+
+object MlirCodegen {
+  type TypesCtx = TypeInference.Ctx
+
+  def mlirType(typ: Type): String =
+    typ match {
+        case RealType => "f64"
+        case BoolType => "i1"
+        case IntType => "i32"
+        case LongType => "i64"
+        case DateType => "i32"
+        case DictType(keyT: Type, valueT: Type, _) =>
+            s"dictionary<${mlirType(keyT)}, ${mlirType(valueT)}>"
+        case RecordType(attrs: Seq[Attribute]) => {
+            val attrsTyped = attrs.map(attr => s"\"${attr.name}\" : ${mlirType(attr.tpe)})")
+            attrsTyped.mkString("record<", ", ", ">")
+        }
+        case StringType(Some(maxLen)) => s"vector<${maxLen}xi8>"
+        case StringType(None) => raise("StringType(None) no supported in MlirCodegen.mlirType()") 
+        case _ => raise(f"unhandled type $typ in MlirCodegen.mlirType()")
+    }
+
+  private final class Fresh {
+    private var i = 0
+    def next(prefix: String): String = {
+        val res = s"${prefix}_$i"
+        i = i + 1
+        res
+    }
+  }
+
+  private val fresh = new Fresh
+
+  case class Emitted(code: Vector[String], value: String)
+
+  def run(e: Exp): Emitted = {
+    def bindToName(x: Exp, desired: Option[String])(implicit ctx : TypesCtx): Emitted = x match {
+      // let x = e1 in e2
+      case LetBinding(x @ Sym(name), e1, e2) => {
+        val boundName = s"%$name"
+        val rhs = bindToName(e1, Some(boundName))
+        val ctx2 = ctx ++ Map(x -> TypeInference.run(e1)(ctx))
+        val body = bindToName(e2, None)(ctx2)
+        Emitted(rhs.code ++ body.code, body.value)
+      }
+
+      case Sym(name) => {
+        val res = s"%$name"
+        Emitted(Vector.empty, res)
+      }
+
+      case Const(v: Int) => {
+        val binding = desired.getOrElse(fresh.next("%consti"))
+        val res = s"$binding = \"arith.constant\"() <{value = $v : i32}> : () -> i32"
+        Emitted(Vector(res), binding)
+      }
+
+      case Const(v: Double) => {
+        val binding = desired.getOrElse(fresh.next("%constd"))
+        val res = s"$binding = \"arith.constant\"() <{value = $v : f64}> : () -> f64"
+        Emitted(Vector(res), binding)
+      }
+
+      case Const(v: Boolean) => {
+        val binding = desired.getOrElse(fresh.next("%constb"))
+        val res = s"$binding = \"arith.constant\"() <{value = ${if(v) 1 else 0} : i1}> : () -> i1"
+        Emitted(Vector(res), binding)
+      }
+
+      // TODO: what's mlir handling of date? for now its i32
+      case Const(v: DateValue) => {
+        val binding = desired.getOrElse(fresh.next("%constda"))
+        val res = s"$binding = \"arith.constant\"() <{value = ${v.v} : i32}> : () -> i32"
+        Emitted(Vector(res), binding)
+      }
+
+      // ex: %dict = sdql.empty_dictionary : dictionary<i32, f16>
+      case DictNode(Nil, _) => {
+        // TODO: handle empty dict (currently type inference breaks)
+        raise(f"unhandled empty dictionary in MlirCodegen.bindToName()")
+
+        // val typ = mlirType(TypeInference.run(x)(ctx))
+        // val binding = desired.getOrElse(fresh.next("%dict"))
+        // Emitted(Vector(s"$binding = sdql.empty_dictionary : $typ"), binding)
+      }
+
+      // ex: %8 = sdql.create_dictionary %5, %7 : i32, i1 -> dictionary<i32, i1>
+      case DictNode(args: Seq[(Exp, Exp)], _: DictHint) => {
+        val resultTyp = mlirType(TypeInference.run(x)(ctx))
+        val allArgs = args.flatMap { case (key, value) => Seq(key, value) }
+        val argTypes = allArgs.map { argTyp => mlirType(TypeInference.run(argTyp)(ctx))}.mkString(", ")
+
+        val binding = desired.getOrElse(fresh.next("%dict"))
+
+        val convertedArgs = allArgs.map(bindToName(_, None))
+        val argOps = convertedArgs.map(_.value).mkString(", ")
+        Emitted(convertedArgs.flatMap(_.code).toVector ++ Vector(s"$binding = sdql.create_dictionary $argOps : $argTypes -> $resultTyp"), binding)
+      }
+        
+      case Get(e1: Exp, e2: Exp) => {
+        val where = bindToName(e1, None)
+
+        val what = bindToName(e2, None)
+
+        val binding = desired.getOrElse(fresh.next("%get"))
+
+        TypeInference.run(e1) match {
+            case _: RecordType => {
+              raise(f"unhandled lookup on RecordType in MlirCodegen.bindToName()")
+            }
+            case dictType: DictType => {
+              // ex: %val = sdql.lookup_dictionary %dict [%key : i32] : dictionary<i32, f16> -> f16
+              val res = s"$binding = sdql.lookup_dictionary ${where.value} [${what.value} : ${mlirType(TypeInference.run(e2))}] : ${mlirType(dictType)} -> ${mlirType(dictType.value)}"
+              Emitted(where.code ++ what.code ++ Vector(res), binding)
+            }
+            case x => {
+              raise(f"unhandled lookup on type ${x.prettyPrint} in MlirCodegen.bindToName()")
+            }
+        }
+      }
+
+      case Load(_: String, _: Type, _: DictNode) => {
+        val binding = desired.getOrElse(fresh.next("%load"))
+        Emitted(Vector(s"$binding = load shananigans"), binding)
+      }
+
+      // sum (x in e1) body
+
+      // %0 = sdql.empty_dictionary : dictionary<i32, f16>
+
+      // %1 = sdql.sum %0 : dictionary<i32, f16> -> f16 {
+      // ^bb0(%x: record<"key": i32, "value": f16>):
+      //   %tmp = sdql.access_record %x "value" : record<"key": i32, "value": f16> -> f16
+      //   sdql.yield %tmp : f16
+      // }
+      case Sum(key: Sym, value: Sym, e1: Exp, body: Exp) => {
+        // key and value present in body but not in e1
+        val e1Evaled = bindToName(e1, None)
+
+        val binding = desired.getOrElse(fresh.next("%sum"))
+
+        val prefix = s"$binding = sdql.sum ${e1Evaled.value} : ${mlirType(TypeInference.run(e1))}"
+
+        // result type? its type of body assuming proper binding key and value
+        val extendedCtx = TypeInference.run(e1) match {
+            case DictType(dictKey: Type, dictVal: Type, _) =>
+                ctx ++ Map(key -> dictKey, value -> dictVal)
+            case x =>
+              raise(f"unhandled sum on type ${x.prettyPrint} in MlirCodegen.bindToName()")
+        }
+
+        val retType = mlirType(TypeInference.run(body)(extendedCtx))
+
+        val blockDecl = s"${fresh.next("^bb")}(%${key.name}: ${mlirType(extendedCtx.get(key).get)}, %${value.name}: ${mlirType(extendedCtx.get(value).get)}):"
+        val blockBody = bindToName(body, None)(extendedCtx)
+        val blockRet = s"  sdql.yield ${blockBody.value} : ${retType}"
+
+        // here we assume result of aggregation of elements of type retType is retType
+        val newOp = Vector(s"$prefix -> $retType {") ++ Vector(blockDecl) ++ blockBody.code.map("  " + _) ++ Vector(blockRet) ++ Vector("}")
+        Emitted(e1Evaled.code ++ newOp, "binding")
+      }
+      
+      // %res = sdql.create_record {fields = ["a", "b"]} %0, %1 : i32, f32 -> record<"a": i32, "b": f32>
+      case RecNode(values) => {
+        val fieldTypes = values.map(_._2).map(TypeInference.run(_))
+        val fieldNames = values.map(_._1)
+
+        val computedFields = values.map(_._2).map(bindToName(_, None))
+        val computedFieldTypes = fieldTypes.map(mlirType(_))
+
+        val binding = desired.getOrElse(fresh.next("%recnode"))
+
+        val fieldsAttr = s"{fields = ${fieldNames.map(name => s"\"$name\"").mkString("[", ", ", "]")}}"
+        
+        val retTypeFields = values.map(field => s"\"${field._1}\": ${mlirType(TypeInference.run(field._2))}").mkString("record<", ", ", ">")
+
+        val op = s"$binding = sdql.create_record $fieldsAttr ${computedFields.map(_.value).mkString(", ")} : ${computedFieldTypes.mkString(", ")} -> $retTypeFields"
+        Emitted(computedFields.flatMap(_.code).toVector ++ Vector(op), binding)
+      }
+        
+      // %val = sdql.access_record %rec "a" : record<"a": i32, "b": f32> -> i32
+      case FieldNode(e: Exp, f: String) => {
+        val inType = TypeInference.run(e) match {
+            case x @ RecordType(_) => x
+            case x @ _ => raise(f"unhandled field access on type ${x.prettyPrint} in MlirCodegen.bindToName()")
+        }
+        val accessedFieldType = inType.attrs.find(_.name == f) match {
+            case Some(attr) => attr.tpe
+            case None => raise(f"unhandled field access due to missing field $f in ${inType.prettyPrint} in MlirCodegen.bindToName()")
+        }
+        val retTypeFields = inType.attrs.map(field => s"\"${field.name}\": ${mlirType(field.tpe)}").mkString("record<", ", ", ">")
+
+        val compE = bindToName(e, None)
+
+        val binding = desired.getOrElse(fresh.next("%fieldnode"))
+
+        val op = s"$binding = sdql.access_record ${compE.value} \"$f\" : $retTypeFields -> ${mlirType(accessedFieldType)} "
+
+        Emitted(compE.code ++ Vector(op), binding)
+      }
+
+      // %0 = "func.call"(%1) <{callee = @range_builtin}> : (i32) -> dictionary<i32, i1>
+      case RangeNode(e: Exp) => {
+        val compE = bindToName(e, None)
+        val binding = desired.getOrElse(fresh.next("%rangenode"))
+        val typ = mlirType(TypeInference.run(e))
+
+        val op = s"$binding = \"func.call\"(${compE.value}) <{callee = @range_builtin}> : ($typ) -> dictionary<$typ, i32>"
+        Emitted(compE.code ++ Vector(op), binding)
+      }
+
+
+/* 
+    %res = "scf.if"(%cond) ({
+        %mul = "arith.mulf"(%l_extendedprice, %l_discount) <{"fastmath" = #arith.fastmath<none>}> : (f64, f64) -> f64
+        "scf.yield"(%mul) : (f64) -> ()
+    }, {
+        %zero = "arith.constant"() <{value = 0.0 : f64}> : () -> f64
+        "scf.yield"(%zero) : (f64) -> ()
+    }) : (i1) -> f64
+ */
+      case IfThenElse(cond, thenp, elsep) => {
+        val outT = mlirType(TypeInference.run(x))
+
+        val c = bindToName(cond, None)
+        val cTyp = mlirType(TypeInference.run(cond))
+
+        val t = bindToName(thenp, None)
+        val tTyp = mlirType(TypeInference.run(thenp))
+
+        val e = bindToName(elsep, None)
+        val eTyp = mlirType(TypeInference.run(elsep))
+
+        val binding = desired.getOrElse(fresh.next("%if"))
+        val code = c.code ++
+            Vector(s"$binding = \"scf.if\"(${c.value}) ({") ++
+            t.code.map("  " + _) ++
+            Vector(s"  \"scf.yield\"(${t.value}) : ($tTyp) -> ()") ++
+            Vector("}, {") ++
+            e.code.map("  " + _) ++
+            Vector(s"  \"scf.yield\"(${e.value}) : ($eTyp) -> ()") ++
+            Vector(s"}) : ($cTyp) -> $outT")
+        Emitted(code, binding)
+      }
+      
+      // %2 = "arith.cmpi"(%0, %1) <{predicate = 3}> : (i32, i32) -> i1
+      case Cmp(e1, e2, cmp)
+        if (TypeInference.run(e1) == IntType || TypeInference.run(e1) == LongType || TypeInference.run(e1) == DateType) &&
+          (TypeInference.run(e2) == IntType || TypeInference.run(e2) == LongType || TypeInference.run(e2) == DateType) => {
+          // is it always i1?
+          val outT = mlirType(TypeInference.run(x))
+
+          val predicateVal = cmp match {
+            // https://mlir.llvm.org/docs/Dialects/ArithOps/#cmpipredicate
+            case "<=" => 3
+            case "<" => 2
+          }
+          val comp1 = bindToName(e1, None)
+          val t1 = mlirType(TypeInference.run(e1))
+          val comp2 = bindToName(e2, None)
+          val t2 = mlirType(TypeInference.run(e2))
+
+          val binding = desired.getOrElse(fresh.next("%cmpi"))
+
+          val op = s"$binding = \"arith.cmpi\"(${comp1.value}, ${comp2.value}) <{predicate = $predicateVal}> : ($t1, $t2) -> $outT"
+          Emitted(comp1.code ++ comp2.code ++ Vector(op), binding)
+        }
+    
+      case Cmp(e1, e2, cmp) if (TypeInference.run(e1) == RealType || TypeInference.run(e2) == RealType) => {
+        // is it always i1?
+        val outT = mlirType(TypeInference.run(x))
+
+        val predicateVal = cmp match {
+          // https://mlir.llvm.org/docs/Dialects/ArithOps/#cmpfpredicate
+          case "<=" => 5
+          case "<" => 4
+        }
+        val comp1 = bindToName(e1, None)
+        val t1 = mlirType(TypeInference.run(e1))
+        val comp2 = bindToName(e2, None)
+        val t2 = mlirType(TypeInference.run(e2))
+
+        val binding = desired.getOrElse(fresh.next("%cmpf"))
+
+        val op = s"$binding = \"arith.cmpf\"(${comp1.value}, ${comp2.value}) <{fastmath = #arith.fastmath<none>, predicate = $predicateVal}> : ($t1, $t2) -> $outT"
+        Emitted(comp1.code ++ comp2.code ++ Vector(op), binding)
+      }
+
+      // %a = arith.muli %b, %c : i64
+      case Mult(e1, e2)
+        if (TypeInference.run(e1) == IntType || TypeInference.run(e1) == LongType) &&
+          (TypeInference.run(e2) == IntType || TypeInference.run(e2) == LongType) => {
+          val outT = mlirType(TypeInference.run(x))
+          
+          val binding = desired.getOrElse(fresh.next("%multi"))
+
+          val comp1 = bindToName(e1, None)
+          val t1 = mlirType(TypeInference.run(e1))
+          val comp2 = bindToName(e2, None)
+          val t2 = mlirType(TypeInference.run(e2))
+
+          val op = s"$binding = \"arith.muli\"(${comp1.value}, ${comp2.value}) : ($t1, $t2) -> $outT"
+          Emitted(comp1.code ++ comp2.code ++ Vector(op), binding)
+      }
+
+      case Mult(e1, e2) if TypeInference.run(e1) == RealType || TypeInference.run(e2) == RealType => {
+          val outT = mlirType(TypeInference.run(x))
+          
+          val binding = desired.getOrElse(fresh.next("%multf"))
+
+          val comp1 = bindToName(e1, None)
+          val t1 = mlirType(TypeInference.run(e1))
+          val comp2 = bindToName(e2, None)
+          val t2 = mlirType(TypeInference.run(e2))
+
+          val op = s"$binding = \"arith.mulf\"(${comp1.value}, ${comp2.value}) <{fastmath = #arith.fastmath<none>}> : ($t1, $t2) -> $outT"
+          Emitted(comp1.code ++ comp2.code ++ Vector(op), binding)
+      }
+
+      case Add(e1, e2) if List(IntType, LongType).contains(TypeInference.run(e1)) => {
+          val outT = mlirType(TypeInference.run(x))
+          
+          val binding = desired.getOrElse(fresh.next("%addi"))
+
+          val comp1 = bindToName(e1, None)
+          val t1 = mlirType(TypeInference.run(e1))
+          val comp2 = bindToName(e2, None)
+          val t2 = mlirType(TypeInference.run(e2))
+
+          val op = s"$binding = \"arith.addi\"(${comp1.value}, ${comp2.value}) : ($t1, $t2) -> $outT"
+          Emitted(comp1.code ++ comp2.code ++ Vector(op), binding)
+
+      }
+
+      case Add(e1, e2) if TypeInference.run(e1) == RealType => {
+          val outT = mlirType(TypeInference.run(x))
+          
+          val binding = desired.getOrElse(fresh.next("%addf"))
+
+          val comp1 = bindToName(e1, None)
+          val t1 = mlirType(TypeInference.run(e1))
+          val comp2 = bindToName(e2, None)
+          val t2 = mlirType(TypeInference.run(e2))
+
+          val op = s"$binding = \"arith.addf\"(${comp1.value}, ${comp2.value}) <{fastmath = #arith.fastmath<none>}> : ($t1, $t2) -> $outT"
+          Emitted(comp1.code ++ comp2.code ++ Vector(op), binding)
+      }
+
+    //   case Neg(e) if TypeInference.run(e) == BoolType => {
+    //     val zero = desired.getOrElse(fresh.next("%zero"))
+    //     val zeroOp = s"$zero = \"arith.constant\"() <{value = 0 : i1}> : () -> i1"
+
+    //     // val res = s"$binding = \"arith.constant\"() <{value = $v : i32}> : () -> i32"
+
+    //     val binding = desired.getOrElse(fresh.next("%neg"))
+
+    //     val comp = bindToName(e, None)
+    //     val op = s"$binding = \"arith.cmpi\"(${comp.value}, $zero) <{predicate = 0}> : (i1, i1) -> i1"
+    //     Emitted(comp.code ++ Vector(zeroOp, op), comp.value)
+    //   }
+
+      case _ => {
+        raise("¯\\_(ツ)_/¯ " + x)
+      }
+    }
+
+    bindToName(e, None)(Map.empty)
+  }
+}

--- a/src/main/scala/sdql/backend/MlirCodegen.scala
+++ b/src/main/scala/sdql/backend/MlirCodegen.scala
@@ -59,7 +59,7 @@ object MlirCodegen {
 
     bindToName(e, None, expectedType = None)(ctx, builder)
 
-    builder.result
+    genRangeBuiltin ++ builder.result
   }
 
   def bindToName(x: Exp, desired: Option[String], expectedType: Option[Type] = None)(implicit
@@ -87,7 +87,9 @@ object MlirCodegen {
 
       case Const(v: Double) =>
         val name = desired.getOrElse(builder.fresh("%constd"))
-        builder.line(s"$name = \"arith.constant\"() <{value = $v : f64}> : () -> f64")
+        builder.line(
+          s"$name = \"arith.constant\"() <{value = ${if (v.toString == "0") "0.0" else v}  : f64}> : () -> f64"
+        )
         V(name, RealType)
 
       case Const(v: Boolean)   =>
@@ -109,7 +111,7 @@ object MlirCodegen {
         builder.line(s"// $v")
         // TODO: handle encoding stuff
         builder.line(
-          s"$name = \"arith.constant\"() <{value = dense<${v.getBytes().mkString("[", ", ", "]")}}> : () -> memref<${v.size}xi1>"
+          s"$name = \"arith.constant\"() <{value = dense<${v.getBytes().mkString("[", ", ", "]")}> : ${mlirType(tpe)}}> : () -> ${mlirType(tpe)}"
         )
         V(name, tpe)
 
@@ -294,14 +296,16 @@ object MlirCodegen {
         // emit then branch
         builder.withIndent {
           val thenBranch = bindToName(thenp, desired = None, expectedType = Some(outTyp))
-          builder.line(s"\"scf.yield\"(${thenBranch.name}) : (${mlirType(outTyp)} -> ()")
+          val upcasted = upcastTo(thenBranch, outTyp)
+          builder.line(s"\"scf.yield\"(${upcasted.name}) : (${mlirType(outTyp)}) -> ()")
         }
         builder.line("}, {")
 
         // emit else branch
         builder.withIndent {
           val elseBranch = bindToName(elsep, desired = None, expectedType = Some(outTyp))
-          builder.line(s"\"scf.yield\"(${elseBranch.name}) : (${mlirType(outTyp)} -> ()")
+          val upcasted = upcastTo(elseBranch, outTyp)
+          builder.line(s"\"scf.yield\"(${upcasted.name}) : (${mlirType(outTyp)}) -> ()")
         }
 
         builder.line(s"}) : (i1) -> ${mlirType(outTyp)}")
@@ -388,33 +392,37 @@ object MlirCodegen {
         )
         V(name, outTyp)
 
-      case Add(e1, e2) if List(IntType, LongType).contains(TypeInference.run(e1)) =>
+      case Add(e1, e2) if List(IntType, LongType).contains(TypeInference.run(x)) =>
         val outTyp = TypeInference.run(x)
         val outT   = mlirType(outTyp)
 
         val name = desired.getOrElse(builder.fresh("%addi"))
 
         val comp1 = bindToName(e1, None)
-        val t1    = mlirType(TypeInference.run(e1))
         val comp2 = bindToName(e2, None)
-        val t2    = mlirType(TypeInference.run(e2))
 
-        builder.line(s"$name = \"arith.addi\"(${comp1.name}, ${comp2.name}) : ($t1, $t2) -> $outT")
+        // operands need to be of the same type
+        val lhs = upcastTo(comp1, outTyp)
+        val rhs = upcastTo(comp2, outTyp)
+
+        builder.line(s"$name = \"arith.addi\"(${lhs.name}, ${rhs.name}) : ($outT, $outT) -> $outT")
         V(name, outTyp)
 
-      case Add(e1, e2) if TypeInference.run(e1) == RealType =>
+      case Add(e1, e2) if TypeInference.run(x) == RealType =>
         val outTyp = TypeInference.run(x)
         val outT   = mlirType(outTyp)
 
         val name = desired.getOrElse(builder.fresh("%addf"))
 
         val comp1 = bindToName(e1, None)
-        val t1    = mlirType(TypeInference.run(e1))
         val comp2 = bindToName(e2, None)
-        val t2    = mlirType(TypeInference.run(e2))
+
+        // operands need to be of the same type
+        val lhs = upcastTo(comp1, outTyp)
+        val rhs = upcastTo(comp2, outTyp)
 
         builder.line(
-          s"$name = \"arith.addf\"(${comp1.name}, ${comp2.name}) <{fastmath = #arith.fastmath<none>}> : ($t1, $t2) -> $outT"
+          s"$name = \"arith.addf\"(${lhs.name}, ${rhs.name}) <{fastmath = #arith.fastmath<none>}> : ($outT, $outT) -> $outT"
         )
         V(name, outTyp)
 
@@ -451,7 +459,7 @@ object MlirCodegen {
         val t    = mlirType(TypeInference.run(e))
 
         val zero = desired.getOrElse(builder.fresh("%zero"))
-        builder.line(s"$zero = \"arith.constant\"() <{value = 0 : $t}> : () -> $t")
+        builder.line(s"$zero = \"arith.constant\"() <{value = 0.0 : $t}> : () -> $t")
 
         builder.line(
           s"$name = \"arith.subf\"($zero, ${comp.name}) <{fastmath = #arith.fastmath<none>}> : ($t, $t) -> $t"
@@ -482,7 +490,7 @@ object MlirCodegen {
         val name = desired.getOrElse(builder.fresh("%external"))
 
         builder.line(
-          s"$name = sdql.external $extName, ${generated.map(_.name).mkString(", ")} : ${types.map(mlirType)}} : ${mlirType(outT)}"
+          s"$name = sdql.external \"$extName\", ${generated.map(_.name).mkString(", ")} : ${types.map(mlirType).mkString(", ")} -> ${mlirType(outT)}"
         )
         V(name, outT)
 
@@ -509,11 +517,66 @@ object MlirCodegen {
         val negated = Cmp(e1, e2, "==")
         bindToName(Neg(negated), desired, expectedType)
 
-      case Unique(_) =>
-        println("unique... " + TypeInference.run(x).prettyPrint)
-        V("1", TypeInference.run(x))
+      // TODO: what does it exactly do?
+      case Unique(e)                       =>
+        val outTyp = TypeInference.run(x)
+
+        val name = desired.getOrElse(builder.fresh("%uniq"))
+
+        val gen   = bindToName(e, None, None)
+        val inTyp = gen.typ
+
+        builder.line(s"$name = sdql.unique ${gen.name} : ${mlirType(inTyp)} -> ${mlirType(outTyp)}")
+        V(name, TypeInference.run(x))
 
       case _ =>
         raise("¯\\_(ツ)_/¯ " + x)
     }
+
+  private def upcastTo(v: V, target: Type)(implicit builder: MlirBuilder): V =
+    (v.typ, target) match {
+      case (IntType, LongType) =>
+        val name = builder.fresh("%extsi")
+        builder.line(s"$name = \"arith.extsi\"(${v.name}) : (i32) -> i64")
+        V(name, LongType)
+
+      case (IntType, RealType) =>
+        val name = builder.fresh("%sitofp")
+        builder.line(s"$name = \"arith.sitofp\"(${v.name}) : (i32) -> f64")
+        V(name, RealType)
+
+      case (LongType, RealType) =>
+        val name = builder.fresh("%sitofp")
+        builder.line(s"$name = \"arith.sitofp\"(${v.name}) : (i64) -> f64")
+        V(name, RealType)
+
+      // TODO handle DateType (acts like i32)
+
+      case (from, to)           =>
+        if (from == to) v else raise(s"no supported upcast from ${from.prettyPrint} to ${to.prettyPrint}")
+    }
+
+  def genRangeBuiltin: Vector[String] =
+    Vector(
+      "func.func @range_builtin(%n: i32) -> dictionary<i32, i32> {",
+      "  %zero = \"arith.constant\"() <{value = 0}> : () -> i32",
+      "  %is_terminal = \"arith.cmpi\"(%n, %zero) <{\"predicate\" = 3}> : (i32, i32) -> i1",
+      "  %res = \"scf.if\"(%is_terminal) ({",
+      "    %empty = sdql.empty_dictionary : dictionary<i32, i32>",
+      "    \"scf.yield\"(%empty) : (dictionary<i32, i32>) -> ()",
+      "  }, {",
+      "    %one = \"arith.constant\"() <{value = 1}> : () -> i32",
+      "    %smaller_n = \"arith.subi\"(%n, %one) : (i32, i32) -> i32",
+      "    %prev_range = \"func.call\"(%smaller_n) <{callee = @range}> : (i32) -> dictionary<i32, i32>",
+      "    %true = \"arith.constant\"() <{value = 1}> : () -> i32",
+      "    %extension = sdql.create_dictionary %smaller_n, %true : i32, i32 -> dictionary<i32, i32>",
+      "",
+      "    // return %extension + %prev_range",
+      "    %added = sdql.dictionary_add %extension %prev_range : dictionary<i32, i32>, dictionary<i32, i32> -> dictionary<i32, i32>",
+      "    \"scf.yield\"(%added) : (dictionary<i32, i32>) -> ()",
+      "  }) : (i1) -> dictionary<i32, i32>",
+      "  func.return %res : dictionary<i32, i32>",
+      "}"
+    )
+
 }

--- a/src/main/scala/sdql/backend/MlirCodegen.scala
+++ b/src/main/scala/sdql/backend/MlirCodegen.scala
@@ -567,7 +567,7 @@ object MlirCodegen {
       "  }, {",
       "    %one = \"arith.constant\"() <{value = 1}> : () -> i32",
       "    %smaller_n = \"arith.subi\"(%n, %one) : (i32, i32) -> i32",
-      "    %prev_range = \"func.call\"(%smaller_n) <{callee = @range}> : (i32) -> dictionary<i32, i32>",
+      "    %prev_range = \"func.call\"(%smaller_n) <{callee = @range_builtin}> : (i32) -> dictionary<i32, i32>",
       "    %true = \"arith.constant\"() <{value = 1}> : () -> i32",
       "    %extension = sdql.create_dictionary %smaller_n, %true : i32, i32 -> dictionary<i32, i32>",
       "",

--- a/src/main/scala/sdql/backend/MlirCodegen.scala
+++ b/src/main/scala/sdql/backend/MlirCodegen.scala
@@ -39,7 +39,7 @@ object MlirCodegen {
   case class Emitted(code: Vector[String], value: String)
 
   def run(e: Exp): Emitted = {
-    def bindToName(x: Exp, desired: Option[String])(implicit ctx : TypesCtx): Emitted = x match {
+    def bindToName(x: Exp, desired: Option[String], expected: Option[Type] = None)(implicit ctx : TypesCtx): Emitted = x match {
       // let x = e1 in e2
       case LetBinding(x @ Sym(name), e1, e2) => {
         val boundName = s"%$name"
@@ -82,11 +82,11 @@ object MlirCodegen {
       // ex: %dict = sdql.empty_dictionary : dictionary<i32, f16>
       case DictNode(Nil, _) => {
         // TODO: handle empty dict (currently type inference breaks)
-        raise(f"unhandled empty dictionary in MlirCodegen.bindToName()")
+        // raise(f"unhandled empty dictionary in MlirCodegen.bindToName()")
 
-        // val typ = mlirType(TypeInference.run(x)(ctx))
-        // val binding = desired.getOrElse(fresh.next("%dict"))
-        // Emitted(Vector(s"$binding = sdql.empty_dictionary : $typ"), binding)
+        val typ = mlirType(expected.get)
+        val binding = desired.getOrElse(fresh.next("%dict"))
+        Emitted(Vector(s"$binding = sdql.empty_dictionary : $typ"), binding)
       }
 
       // ex: %8 = sdql.create_dictionary %5, %7 : i32, i1 -> dictionary<i32, i1>
@@ -233,8 +233,8 @@ object MlirCodegen {
         val t = bindToName(thenp, None)
         val tTyp = mlirType(TypeInference.run(thenp))
 
-        val e = bindToName(elsep, None)
-        val eTyp = mlirType(TypeInference.run(elsep))
+        // val eTyp = mlirType(TypeInference.run(elsep))
+        val e = bindToName(elsep, None, Some(TypeInference.run(x)))
 
         val binding = desired.getOrElse(fresh.next("%if"))
         val code = c.code ++
@@ -243,7 +243,7 @@ object MlirCodegen {
             Vector(s"  \"scf.yield\"(${t.value}) : ($tTyp) -> ()") ++
             Vector("}, {") ++
             e.code.map("  " + _) ++
-            Vector(s"  \"scf.yield\"(${e.value}) : ($eTyp) -> ()") ++
+            Vector(s"  \"scf.yield\"(${e.value}) : (${tTyp}) -> ()") ++
             Vector(s"}) : ($cTyp) -> $outT")
         Emitted(code, binding)
       }
@@ -363,6 +363,46 @@ object MlirCodegen {
     //     val op = s"$binding = \"arith.cmpi\"(${comp.value}, $zero) <{predicate = 0}> : (i1, i1) -> i1"
     //     Emitted(comp.code ++ Vector(zeroOp, op), comp.value)
     //   }
+      case Neg(e) if List(IntType, LongType).contains(TypeInference.run(e)) => {          
+          val binding = desired.getOrElse(fresh.next("%addf"))
+
+          val comp = bindToName(e, None)
+          val t = mlirType(TypeInference.run(e))
+
+          val zero = desired.getOrElse(fresh.next("%zero"))
+          val zeroOp = s"$zero = \"arith.constant\"() <{value = 0 : $t}> : () -> $t"
+
+          val op = s"$binding = \"arith.subi\"($zero, ${comp.value}) : ($t, $t) -> $t"
+          Emitted(comp.code ++ Vector(zeroOp) ++ Vector(op), binding)
+      }
+      case Neg(e) if TypeInference.run(e) == RealType => {          
+          val binding = desired.getOrElse(fresh.next("%addf"))
+
+          val comp = bindToName(e, None)
+          val t = mlirType(TypeInference.run(e))
+
+          val zero = desired.getOrElse(fresh.next("%zero"))
+          val zeroOp = s"$zero = \"arith.constant\"() <{value = 0 : $t}> : () -> $t"
+
+          val op = s"$binding = \"arith.subf\"($zero, ${comp.value}) <{fastmath = #arith.fastmath<none>}> : ($t, $t) -> $t"
+          Emitted(comp.code ++ Vector(zeroOp) ++ Vector(op), binding)
+      }
+
+      case Concat(e1, e2)
+      if TypeInference.run(e1).isInstanceOf[RecordType] && TypeInference.run(e2).isInstanceOf[RecordType] => {
+        val outT = TypeInference.run(x)
+
+        val typ1 = mlirType(TypeInference.run(e1))
+        val typ2 = mlirType(TypeInference.run(e2))
+
+        val gen1 = bindToName(e1, None)
+        val gen2 = bindToName(e2, None)
+
+        val binding = desired.getOrElse(fresh.next("%concat"))
+
+        val op = s"$binding = sdql.concat ${gen1.value}, ${gen2.value} : $typ1, $typ2 -> $outT"
+        Emitted(gen1.code ++ gen2.code ++ Vector(op), binding)
+      }
 
       case _ => {
         raise("¯\\_(ツ)_/¯ " + x)

--- a/src/main/scala/sdql/driver/Main.scala
+++ b/src/main/scala/sdql/driver/Main.scala
@@ -45,56 +45,13 @@ object Main {
           println()
         }
       case "to_mlir" =>
-        if (args.length < 3) { raise("usage: `run to_mlir <path> <sdql_files>*`") }
-        // val dirPath   = Path.of(args(1))
-        // val fileNames = args.drop(2)
-        // CppCompile.cmake(dirPath, fileNames)
-        // for (_ <- fileNames) {
-        // val filePath = dirPath.resolve(fileName)
-        val q: Exp = LetBinding(Sym("dict"),
-          // empty dictionary literal
-          DictNode(Seq(
-            Const(1) -> Const(2.0)   // { 1 -> 2.0 }
-          ), PHmap(None)),
-          LetBinding(Sym("key"),
-            Const(1),
-            // lookup
-            Get(Sym("dict"), Sym("key"))
-          )
-        )
-        val prog = MlirCodegen.run(q)
-        println(prog.mkString("\n"))
-
-        val q2: Exp =
-          LetBinding(Sym("outer"),
-            // outer : dictionary<i32, dictionary<i32, f64>>
-            DictNode(Seq(
-              // 1 -> { 10 -> 2.0, 20 -> 3.5 }
-              Const(1) -> DictNode(Seq(
-                Const(10) -> Const(2.0),
-                Const(20) -> Const(3.5)
-              ), PHmap(None)),
-
-              // 3 -> { 30 -> 4.25 }
-              Const(3) -> DictNode(Seq(
-                Const(30) -> Const(4.25)
-              ), PHmap(None))
-            ), PHmap(None)),
-
-            // body: look up outer[1][20]
-            LetBinding(Sym("kOuter"), Const(1),
-              LetBinding(Sym("kInner"), Const(20),
-                LetBinding(Sym("inner"),
-                  Get(Sym("outer"), Sym("kOuter")),     // inner = outer[kOuter]
-                  Get(Sym("inner"), Sym("kInner"))      // result = inner[kInner]
-                )
-              )
-            )
-          )
-          val prog2 = MlirCodegen.run(q2)
-          println("\nprog2: ")
-          println(prog2.mkString("\n"))
-        // }
+        if (args.length != 3) { raise("usage: `run to_mlir <path> <sdql_file>`") }
+        val dirPath   = Path.of(args(1))
+        val fileName = args(2)
+        val filePath = dirPath.resolve(fileName)
+        val prog     = SourceCode.fromFile(filePath.toString).exp
+        val mlirProg = MlirCodegen.run(prog)
+        println(mlirProg.mkString("\n"))
       case "benchmark" =>
         if (args.length < 4) { raise("usage: `run benchmark n <path> <sdql_files>*`") }
         val n         = args(1).toInt

--- a/src/main/scala/sdql/driver/Main.scala
+++ b/src/main/scala/sdql/driver/Main.scala
@@ -33,11 +33,6 @@ object Main {
         for (fileName <- fileNames) {
           val filePath = dirPath.resolve(fileName)
           val prog     = SourceCode.fromFile(filePath.toString).exp
-          println("prog: " + prog)
-          val procodegened = MlirCodegen.run(prog)
-          println(procodegened.mkString("\n"))
-
-          println(prog)
           val llql     = Rewriter.rewrite(prog)
           val res      = CppCodegen(llql)
           println(fileName)

--- a/src/main/scala/sdql/driver/Main.scala
+++ b/src/main/scala/sdql/driver/Main.scala
@@ -7,6 +7,7 @@ import sdql.ir.*
 import sdql.transformations.Rewriter
 
 import java.nio.file.Path
+import sdql.backend.MlirCodegen
 
 object Main {
   def main(args: Array[String]): Unit = {
@@ -32,12 +33,68 @@ object Main {
         for (fileName <- fileNames) {
           val filePath = dirPath.resolve(fileName)
           val prog     = SourceCode.fromFile(filePath.toString).exp
+          println("prog: " + prog)
+          val procodegened = MlirCodegen.run(prog)
+          println(procodegened.code.mkString("\n"))
+
+          println(prog)
           val llql     = Rewriter.rewrite(prog)
           val res      = CppCodegen(llql)
           println(fileName)
           println(CppCompile.compile(filePath.toString, res))
           println()
         }
+      case "to_mlir" =>
+        if (args.length < 3) { raise("usage: `run to_mlir <path> <sdql_files>*`") }
+        // val dirPath   = Path.of(args(1))
+        // val fileNames = args.drop(2)
+        // CppCompile.cmake(dirPath, fileNames)
+        // for (_ <- fileNames) {
+        // val filePath = dirPath.resolve(fileName)
+        val q: Exp = LetBinding(Sym("dict"),
+          // empty dictionary literal
+          DictNode(Seq(
+            Const(1) -> Const(2.0)   // { 1 -> 2.0 }
+          ), PHmap(None)),
+          LetBinding(Sym("key"),
+            Const(1),
+            // lookup
+            Get(Sym("dict"), Sym("key"))
+          )
+        )
+        val prog = MlirCodegen.run(q)
+        println(prog.code.mkString("\n"))
+
+        val q2: Exp =
+          LetBinding(Sym("outer"),
+            // outer : dictionary<i32, dictionary<i32, f64>>
+            DictNode(Seq(
+              // 1 -> { 10 -> 2.0, 20 -> 3.5 }
+              Const(1) -> DictNode(Seq(
+                Const(10) -> Const(2.0),
+                Const(20) -> Const(3.5)
+              ), PHmap(None)),
+
+              // 3 -> { 30 -> 4.25 }
+              Const(3) -> DictNode(Seq(
+                Const(30) -> Const(4.25)
+              ), PHmap(None))
+            ), PHmap(None)),
+
+            // body: look up outer[1][20]
+            LetBinding(Sym("kOuter"), Const(1),
+              LetBinding(Sym("kInner"), Const(20),
+                LetBinding(Sym("inner"),
+                  Get(Sym("outer"), Sym("kOuter")),     // inner = outer[kOuter]
+                  Get(Sym("inner"), Sym("kInner"))      // result = inner[kInner]
+                )
+              )
+            )
+          )
+          val prog2 = MlirCodegen.run(q2)
+          println("\nprog2: ")
+          println(prog2.code.mkString("\n"))
+        // }
       case "benchmark" =>
         if (args.length < 4) { raise("usage: `run benchmark n <path> <sdql_files>*`") }
         val n         = args(1).toInt

--- a/src/main/scala/sdql/driver/Main.scala
+++ b/src/main/scala/sdql/driver/Main.scala
@@ -35,7 +35,7 @@ object Main {
           val prog     = SourceCode.fromFile(filePath.toString).exp
           println("prog: " + prog)
           val procodegened = MlirCodegen.run(prog)
-          println(procodegened.code.mkString("\n"))
+          println(procodegened.mkString("\n"))
 
           println(prog)
           val llql     = Rewriter.rewrite(prog)
@@ -63,7 +63,7 @@ object Main {
           )
         )
         val prog = MlirCodegen.run(q)
-        println(prog.code.mkString("\n"))
+        println(prog.mkString("\n"))
 
         val q2: Exp =
           LetBinding(Sym("outer"),
@@ -93,7 +93,7 @@ object Main {
           )
           val prog2 = MlirCodegen.run(q2)
           println("\nprog2: ")
-          println(prog2.code.mkString("\n"))
+          println(prog2.mkString("\n"))
         // }
       case "benchmark" =>
         if (args.length < 4) { raise("usage: `run benchmark n <path> <sdql_files>*`") }


### PR DESCRIPTION
This PR contains an implementation for MLIR codegen using the new `sdql` dialect in [scair](https://github.com/edin-dal/scair) (see https://github.com/edin-dal/scair/pull/391).

## How to emit the MLIR code
Usage: `run to_mlir <path> <sdql_file>`
Example: `run to_mlir progs/tpch q6.sdql`

## TPC-H coverage
Codegen succeeds for 19/22 queries. Current failures: q4, q15, and q22.

MLIR code for queries can be generated using `gen_tpch_mlir.sh`
Example: `./gen_tpch_mlir.sh /tmp/tpch-queries-mlir`

## Known limitations
- Untyped empty dicts can break codegen when their type must be inferred. A fix is partially implemented (passing an “expected type” through function calls), but some edge cases remain.
- Some language features are not yet supported (e.g., `Load.skipCols`, `DictNode.hint`).
- The `date` type is lowered to `i32`. It should be investigated how it should be represented in MLIR.
- Local SSA/value name collisions can occur with certain bound variable names.